### PR TITLE
2.14

### DIFF
--- a/common/Bindable.sk
+++ b/common/Bindable.sk
@@ -1,12 +1,11 @@
 using script reflection
-using for loop
 
 struct Bindable:
 	previous: object
 	value: object
 	callbacks: objects
 
-function a_bindable(value: object = {_}, callbacks: objects = {_}, previous: object = {_}) :: Bindable struct:
+function a_bindable(value: object = {_}, callbacks: objects = {_}, previous: object = {_}) -> Bindable struct:
 	return Bindable struct instance:
 		value: {_value}
 		callbacks: {_callbacks::*}
@@ -42,22 +41,22 @@ effect unbind %objects% from %Bindable struct%:
 	trigger:
 		bind_unbind(expr-2, exprs-1)
 
-function bind_get(bindable: Bindable struct) :: object:
+function bind_get(bindable: Bindable struct) -> object:
 	return field value of {_bindable}
 
-function bind_add(bindable: Bindable struct, value: object) :: boolean:
+function bind_add(bindable: Bindable struct, value: object) -> boolean:
 	set field previous of {_bindable} to field value of {_bindable}
 	set {_temp_value} to field value of {_bindable}
 	add {_value} to {_temp_value}
 	set field value of {_bindable} to {_temp_value}
 	trigger_update({_bindable}, {_value})
 
-function bind_set(bindable: Bindable struct, value: object) :: boolean:
+function bind_set(bindable: Bindable struct, value: object) -> boolean:
 	set field previous of {_bindable} to field value of {_bindable}
 	set field value of {_bindable} to {_value}
 	trigger_update({_bindable}, {_value})
 
-function bind_set_silently(bindable: Bindable struct, value: object) :: boolean:
+function bind_set_silently(bindable: Bindable struct, value: object) -> boolean:
 	set field value of {_bindable} to {_value}
 
 function bind_remove(bindable: Bindable struct, value: object):: boolean:
@@ -67,24 +66,24 @@ function bind_remove(bindable: Bindable struct, value: object):: boolean:
 	set field value of {_bindable} to {_temp_value}
 	trigger_update({_bindable}, {_value})
 
-function bind_delete(bindable: Bindable struct) :: boolean:
+function bind_delete(bindable: Bindable struct) -> boolean:
 	set field previous of {_bindable} to field value of {_bindable}
 	delete field value of {_bindable}
 	trigger_update({_bindable}, {_value})
 
-function bind_dispose(bindable: Bindable struct) :: boolean:
+function bind_dispose(bindable: Bindable struct) -> boolean:
 	delete {_bindable}
 
-function bind_bind(bindable: Bindable struct, callbacks: objects) :: boolean:
+function bind_bind(bindable: Bindable struct, callbacks: objects) -> boolean:
 	add {_callbacks::*} to field callbacks of {_bindable}
 
-function bind_unbind(bindable: Bindable struct, callbacks: objects) :: boolean:
+function bind_unbind(bindable: Bindable struct, callbacks: objects) -> boolean:
 	for {_remove} in ({_callbacks::*} where [input is a function]):
 		for {_callback} in (field callbacks of {_bindable} where [fn_equal(input, {_remove}) = true]):
 			remove {_callback} from field callbacks of {_bindable}
 	remove {_callbacks::*} from field callbacks of {_bindable}
 
-local function fn_equal(a: function, b: function) :: boolean:
+local function fn_equal(a: function, b: function) -> boolean:
 	if all:
 		name of {_a} = name of {_b}
 		{_a}.source() = {_b}.source()
@@ -99,7 +98,7 @@ function trigger_update(bindable: Bindable struct, value: object = {_}):
 		else:
 			run {_callback} with arguments {_bindable}, {_value}
 
-function lerp_bindable(bindable: Bindable struct, progress: number) :: number:
+function lerp_bindable(bindable: Bindable struct, progress: number) -> number:
     if {_bindable}->previous = {_bindable}->value:
         return {_bindable}->value
     set {_previous} to {_bindable}->previous

--- a/common/Color.sk
+++ b/common/Color.sk
@@ -1,10 +1,10 @@
-function lerp_color(from: color, to: color, progress: number) :: color:
+function lerp_color(from: color, to: color, progress: number) -> color:
     set {_r} to ({_from}'s red value   + (({_to}'s red value   - {_from}'s red value)   * {_progress}))
     set {_g} to ({_from}'s green value + (({_to}'s green value - {_from}'s green value) * {_progress}))
     set {_b} to ({_from}'s blue value  + (({_to}'s blue value  - {_from}'s blue value)  * {_progress}))
     return rgb(clamp({_r}, 0, 255), clamp({_g}, 0, 255), clamp({_b}, 0, 255))
 
-function flash_color(color: color, flash: color, progress: number) :: color:
+function flash_color(color: color, flash: color, progress: number) -> color:
     set {_r} to round(({_color}'s red value   * (1 - {_progress})) + ({_flash}'s red value   * {_progress}))
     set {_g} to round(({_color}'s green value * (1 - {_progress})) + ({_flash}'s green value * {_progress}))
     set {_b} to round(({_color}'s blue value  * (1 - {_progress})) + ({_flash}'s blue value  * {_progress}))

--- a/common/Component.sk
+++ b/common/Component.sk
@@ -1,91 +1,90 @@
-using for loops
 
 import:
     org.bukkit.map.MinecraftFont
     net.kyori.adventure.text.format.ShadowColor
 
-function width(string: string) :: integer:
+function width(string: string) -> integer:
     return MinecraftFont.Font.getWidth({_string})
 
-function shadow(component: textcomponent) :: textcomponent:
+function shadow(component: textcomponent) -> textcomponent:
     {_component}.setComponent({_component}.getComponent().shadowColor(ShadowColor.none()))
     return {_component}
 
-function shadow(component: textcomponent, color: color) :: textcomponent:
+function shadow(component: textcomponent, color: color) -> textcomponent:
     {_component}.setComponent({_component}.getComponent().shadowColor(ShadowColor.shadowColor((red value of {_color}), (green value of {_color}), (blue value of {_color}), (alpha value of {_color}))))
     return {_component}
 
-function sprite(path: string, frame: integer = {_}) :: textcomponent:
+function sprite(path: string, frame: integer = {_}) -> textcomponent:
     if {_frame} is set:
         add "_%{_frame}%" to {_path}
     set {_parts::*} to {_path} split at ":"
     return object text component with atlas {_parts::1} with sprite {_parts::2}
 
-function merge(components: textcomponents, joiner: textcomponent = empty text component) :: textcomponent:
+function merge(components: textcomponents, joiner: textcomponent = empty text component) -> textcomponent:
     return merge components {_components::*} with {_joiner}
 
-function c(text: text) :: textcomponent:
+function c(text: text) -> textcomponent:
     return text component of {_text}
 
-function cs(texts: texts) :: textcomponents:
+function cs(texts: texts) -> textcomponents:
     return text component of {_texts::*}
 
-function component() :: textcomponent:
+function component() -> textcomponent:
     return empty text component
 
-function component(text: text) :: textcomponent:
+function component(text: text) -> textcomponent:
     return text component of {_text}
 
-function components(texts: texts) :: textcomponents:
+function components(texts: texts) -> textcomponents:
     return text component of {_texts::*}
 
-function new_line_component() :: textcomponent:
+function new_line_component() -> textcomponent:
     return (minimessage from "<br>")
 
-function blank() :: textcomponent:
+function blank() -> textcomponent:
     return c("")
 
-function px(px: integer) :: textcomponent:
+function px(px: integer) -> textcomponent:
     set {_component} to c(((character at codepoint 8204) repeated {_px} times) ? "")
     set bold format of {_component} to true
     return {_component}
 
-function colored_component(text: text, color: color) :: textcomponent:
+function colored_component(text: text, color: color) -> textcomponent:
     set {_component} to c({_text})
     set color format of {_component} to {_color}
     return {_component}
 
-function wrap_around(component: textcomponent, left: textcomponent, right: textcomponent, brightness: number) :: textcomponent:
+function wrap_around(component: textcomponent, left: textcomponent, right: textcomponent, brightness: number) -> textcomponent:
     set {_children::*} to (component children of {_component}) ? ({_component}, {_component})
     set color format of {_left} to change_brightness(color format of (first element of {_children::*}), {_brightness})
     set color format of {_right} to change_brightness(color format of (last element of {_children::*}), {_brightness})
     return merge components ({_left}, {_component}, {_right})
 
-function change_brightness(color: color, amount: number) :: color:
+function change_brightness(color: color, amount: number) -> color:
     set {_r} to clamp(red value of {_color} * {_amount}, 0, 255)
     set {_g} to clamp(green value of {_color} * {_amount}, 0, 255)
     set {_b} to clamp(blue value of {_color} * {_amount}, 0, 255)
     return rgb({_r}, {_g}, {_b})
 
-function shift_brightness(component: textcomponent, amount: number) :: textcomponent:
+function shift_brightness(component: textcomponent, amount: number) -> textcomponent:
     set color format of {_component} to change_brightness(color format of {_component}, {_amount})
     return {_component}
 
-function rgba(r: number, g: number, b: number, a: number) :: color:
+function rgba(r: number, g: number, b: number, a: number) -> color:
     return rgb({_r}, {_g}, {_b}, {_a} * 255)
 
-function rgba(r: number, g: number, b: number) :: color:
+function rgba(r: number, g: number, b: number) -> color:
     return rgb({_r}, {_g}, {_b}, 255)
 
-function component_real(value: number, color: color, positive: color, negative: color, spacing: integer = 1) :: textcomponent:
+function component_real(value: number, color: color, positive: color, negative: color, spacing: integer = 1) -> textcomponent:
     set {_symbol} to colored_component("+", {_positive}) if ({_value} > 0) else colored_component("-", {_negative})
     return merge components {_symbol}, px({_spacing}), colored_component("%{_value}%", {_color})
 
-function component_unit(value: number, unit: string, color: color, secondary_color: color, spacing: integer = 1) :: textcomponent:
+function component_unit(value: number, unit: string, color: color, secondary_color: color, spacing: integer = 1) -> textcomponent:
     return merge components colored_component("%{_value}%", {_color}), px({_spacing}), colored_component({_unit}, {_secondary_color})
 
-function component_fraction(numerator: number, denominator: number, numerator_color: color, denominator_color: color, spacing: integer = 2) :: textcomponent:
+function component_fraction(numerator: number, denominator: number, numerator_color: color, denominator_color: color, spacing: integer = 2) -> textcomponent:
     return merge components colored_component("%{_numerator}%", {_numerator_color}), px({_spacing} / 2), colored_component("/", {_denominator_color}), px({_spacing} / 2), colored_component("%{_denominator}%", {_denominator_color})
 
-function component_percent(value: number, color: color, secondary_color: color, spacing: integer = 1) :: text component:
+function component_percent(value: number, color: color, secondary_color: color, spacing: integer = 1) -> text component:
     return merge components colored_component("%{_value}%", {_color}), px({_spacing}), colored_component("%%", {_secondary_color})

--- a/common/Compound.sk
+++ b/common/Compound.sk
@@ -1,9 +1,8 @@
-using for loops
 
-function compound_as_list(compound: nbt) :: objects:
+function compound_as_list(compound: nbt) -> objects:
     for {_tag} in nbt tags of {_compound}:
         set {_list::%{_tag}%} to tag({_compound}, {_tag})
     return keyed {_list::*}
 
-function tag(compound: nbt, tag: string) :: object:
+function tag(compound: nbt, tag: string) -> object:
     return (tagtype of tag {_tag} of {_compound}) {_tag} of {_compound}

--- a/common/Cooldown.sk
+++ b/common/Cooldown.sk
@@ -28,7 +28,7 @@ function delete_cooldown(id: string, holder: metadataholder = {_}):
 #> @param id The id of the cooldown
 #> @param holder (Optional) The holder of the cooldown
 #> @return The remaining time of the cooldown
-function remaining_cooldown(id: string, holder: metadataholder = {_}) :: timespan:
+function remaining_cooldown(id: string, holder: metadataholder = {_}) -> timespan:
     set {_remaining} to cooldown_duration({_id}, {_holder}) - (time since cooldown_start({_id}, {_holder}))
     return {_remaining} if {_remaining} > 0 seconds
     delete_cooldown({_id}, {_holder})
@@ -39,7 +39,7 @@ function remaining_cooldown(id: string, holder: metadataholder = {_}) :: timespa
 #> @param id The id of the cooldown
 #> @param holder (Optional) The holder of the cooldown
 #> @return The start date of the cooldown
-function cooldown_start(id: string, holder: metadataholder = {_}) :: date:
+function cooldown_start(id: string, holder: metadataholder = {_}) -> date:
     return {-mib_lib::cooldown::%{_id}%::%{_holder}%::start}
 
 #> Returns the duration of a cooldown with an id and holder
@@ -47,7 +47,7 @@ function cooldown_start(id: string, holder: metadataholder = {_}) :: date:
 #> @param id The id of the cooldown
 #> @param holder (Optional) The holder of the cooldown
 #> @return The duration of the cooldown
-function cooldown_duration(id: string, holder: metadataholder = {_}) :: timespan:
+function cooldown_duration(id: string, holder: metadataholder = {_}) -> timespan:
     return {-mib_lib::cooldown::%{_id}%::%{_holder}%::duration}
 
 #> Returns whether the cooldown with an id and holder is active
@@ -55,7 +55,7 @@ function cooldown_duration(id: string, holder: metadataholder = {_}) :: timespan
 #> @param id The id of the cooldown
 #> @param holder (Optional) The holder of the cooldown
 #> @return Whether the cooldown is active
-function is_on_cooldown(id: string, holder: metadataholder = {_}) :: boolean:
+function is_on_cooldown(id: string, holder: metadataholder = {_}) -> boolean:
     return whether remaining_cooldown({_id}, {_holder}) > 0 seconds
 
 # ------------------------
@@ -81,5 +81,5 @@ on load:
 # m: minute (0-59)
 # s: second (0-59)
 #
-function format_timespan(timespan: timespan, format: string = {-default_timespan_format}) :: string:
+function format_timespan(timespan: timespan, format: string = {-default_timespan_format}) -> string:
     return ({_timespan} after {-unix_zero_date}) formatted as {_format}

--- a/common/Display.sk
+++ b/common/Display.sk
@@ -1,7 +1,7 @@
 import:
     com.shanebeestudios.skbee.api.wrapper.ComponentWrapper
 
-function a_display(type: entity type) :: display:
+function a_display(type: entity type) -> display:
     spawn {_type} at location(0, -50, 0):
         set {_entity} to display
         set teleport duration of entity to 2 tick
@@ -10,13 +10,13 @@ function a_display(type: entity type) :: display:
         make entity not persist
     return {_entity}
 
-function a_block_display() :: display:
+function a_block_display() -> display:
     return a_display(a block display)
 
-function a_item_display() :: display:
+function a_item_display() -> display:
     return a_display(a item display)
 
-function a_text_display() :: display:
+function a_text_display() -> display:
     return a_display(a text display)
 
 function interpolate(displays: displays):

--- a/common/Filter.sk
+++ b/common/Filter.sk
@@ -191,7 +191,7 @@ struct FilterResult:
 #
 # This is moderately safe to run asynchronously, as long as only one call to filter_message() is made at a time.
 # Using it in the async chat event should be relatively safe, though not guaranteed if you have a lot of players chatting at once.
-function filter_message(message: text, sender: sender, match all: boolean = false) :: struct:
+function filter_message(message: text, sender: sender, match all: boolean = false) -> struct:
     set {_result} to a FilterResult struct instance:
         matched: false
         severity: 0
@@ -255,7 +255,7 @@ function regenerate_patterns():
     sort {-{@cf}::filtered phrases::*} in descending order by (input->strictness)    
 
 # generates a regex Pattern object for a phrase, based on boundary and strictness
-local function generate_pattern(phrase: text, boundary: boolean, strictness: number) :: javaobject:
+local function generate_pattern(phrase: text, boundary: boolean, strictness: number) -> javaobject:
     set {_pattern} to ""
     # generate alternate characters map
     set {_characters::*} to {_phrase} split at "" without trailing string
@@ -296,13 +296,13 @@ local function use_separators(separators: texts):
         set {-{@cf}::separators::%loop-index%} to {_char}
 
 # returns a regex pattern string matching zero or more separator characters
-local function separators_pattern() :: text:
+local function separators_pattern() -> text:
     if {-{@cf}::separators::*} is set:
         return "[%join {-{@cf}::separators::*}%]*"
     return ""
 
 # returns a regex pattern string matching the character and its alternates based on strictness
-local function alternates_pattern(char: text, strictness: number) :: text:
+local function alternates_pattern(char: text, strictness: number) -> text:
     if any:
         {_strictness} is 3
         {-{@cf}::alternates::%{_char}%} is not set

--- a/common/Functional.sk
+++ b/common/Functional.sk
@@ -4,7 +4,6 @@
 #
 # This module requires the following other modules: NONE
 
-using for loops
 using script reflection
 
 #> A shorthand for getting a function by its name
@@ -13,7 +12,7 @@ using script reflection
 #> @param name The name of the function to retrieve
 #> @param script (Optional) The script where the function is defined
 #> @return The function if found, none if not registered
-function fn(name: string, script: string = {_}) :: function:
+function fn(name: string, script: string = {_}) -> function:
 	return function named {_name} in (script {_script})
 
 #> The id function returns the object given to it without any changes
@@ -22,7 +21,7 @@ function fn(name: string, script: string = {_}) :: function:
 #>
 #> @param value Any object
 #> @return The object passed in
-function id(value: object) :: object:
+function id(value: object) -> object:
 	return {_value}
 
 #> The ids function returns the objects given to it without any changes
@@ -31,7 +30,7 @@ function id(value: object) :: object:
 #>
 #> @param value Any objects
 #> @return The objects passed in
-function ids(value: objects) :: objects:
+function ids(value: objects) -> objects:
 	return {_value::*}
 
 #> Applies a function to each item in a collection
@@ -50,7 +49,7 @@ function foreach(collection: objects, transformer: function):
 #> @param initial_value The starting value for the reduction
 #> @param combiner A function that takes two arguments: the current result and the next item, returning a new result
 #> @return The final reduced value
-function reduce(collection: objects, initial_value: object, combiner: function) :: object:
+function reduce(collection: objects, initial_value: object, combiner: function) -> object:
 	set {_result} to {_initial_value}
 	for {_item} in {_collection::*}:
 		set {_result} to result of {_combiner} with args {_result}, {_item}

--- a/common/HashMap.sk
+++ b/common/HashMap.sk
@@ -1,6 +1,5 @@
-using for loops
 
-function hash_map_as_list(hash_map: object) :: objects:
+function hash_map_as_list(hash_map: object) -> objects:
     for {_key} in ...{_hash_map}.keySet():
         set {_list::%{_key}%} to {_hash_map}.get({_key})
     return keyed {_list::*}

--- a/common/Interaction.sk
+++ b/common/Interaction.sk
@@ -1,36 +1,3 @@
-import:
-    org.bukkit.entity.Interaction
-
-entity property interaction width:
-    return type: number
-    get:
-        return expr-1.getInteractionWidth()
-    set:
-        expr-1.setInteractionWidth(change value)
-    add:
-        expr-1.setInteractionWidth(expr-1.getInteractionWidth() + change value)
-    remove:
-        expr-1.setInteractionWidth((expr-1.getInteractionWidth()) - change value)
-    delete:
-        expr-1.setInteractionWidth(0)
-    reset:
-        expr-1.setInteractionWidth(1)
-
-entity property interaction height:
-    return type: number
-    get:
-        return expr-1.getInteractionHeight()
-    set:
-        expr-1.setInteractionHeight(change value)
-    add:
-        expr-1.setInteractionHeight(expr-1.getInteractionHeight() + change value)
-    remove:
-        expr-1.setInteractionHeight((expr-1.getInteractionHeight()) - change value)
-    delete:
-        expr-1.setInteractionHeight(0)
-    reset:
-        expr-1.setInteractionHeight(1)
-
 entity property interaction scale:
     return type: vector
     get:
@@ -44,14 +11,11 @@ entity property interaction scale:
     remove:
         remove ((x of change value) + (z of change value)) / 2 from interaction width of expr-1
         remove (y of change value) from interaction height of expr-1
-    delete:
-        delete interaction width of expr-1
-        delete interaction height of expr-1
     reset:
         reset interaction width of expr-1
         reset interaction height of expr-1
 
-function a_interaction() :: entity:
+function a_interaction() -> entity:
     spawn interaction at location(0, -50, 0):
         set {_entity} to entity
         make entity not persist

--- a/common/Math.sk
+++ b/common/Math.sk
@@ -12,7 +12,7 @@ on script load:
 #> @param to The maximum integer value.
 #> @param from The minimum integer value. Defaults to **0**.
 #> @return A random integer from **from** to **to**.
-function rndi(to: integer, from: integer = 0) :: integer:
+function rndi(to: integer, from: integer = 0) -> integer:
 	return random integer from {_from} to {_to}
 
 #> Returns a random floating-point number between **from** and **to**.
@@ -21,7 +21,7 @@ function rndi(to: integer, from: integer = 0) :: integer:
 #> @param to The maximum number value.
 #> @param from The minimum number value. Defaults to **0**.
 #> @return A random number from **from** to **to**.
-function rnd(to: number, from: number = 0) :: number:
+function rnd(to: number, from: number = 0) -> number:
 	return random number from {_from} to {_to}
 
 #> Linearly interpolates between **a** and **b** at **time**
@@ -32,14 +32,14 @@ function rnd(to: number, from: number = 0) :: number:
 #> @param b The end number.
 #> @param time A value indicating the interpolation factor.
 #> @return The interpolated number between **a** and **b**.
-function lerp(a: number, b: number, time: number = 0.5) :: number:
+function lerp(a: number, b: number, time: number = 0.5) -> number:
 	return {_a} * (1 - {_time}) + {_b} * {_time}
 
 #> Returns the sign of a number.
 #>
 #> @param value The number to check.
 #> @return -1 if negative, 1 if positive, 0 if zero.
-function sign(value: number) :: integer:
+function sign(value: number) -> integer:
 	return -1 if {_value} < 0
 	return 1 if {_value} > 0
 	return 0
@@ -49,7 +49,7 @@ function sign(value: number) :: integer:
 #>
 #> @param value A number between 0 and 1.
 #> @return The smoothed value.
-function smooth_step(value: number) :: number:
+function smooth_step(value: number) -> number:
 	return {_value} * {_value} * (3 - 2 * {_value})
 
 #> Oscillates a value back and forth between 0 and n.
@@ -60,7 +60,7 @@ function smooth_step(value: number) :: number:
 #> @param value The input number.
 #> @param n Where the value turns
 #> @return A number oscillating between 0 and n.
-function ping_pong(value: number, n: number = 1) :: number:
+function ping_pong(value: number, n: number = 1) -> number:
 	return 0 if {_n} = 0 # Divide by 0 errors
 	return abs(fract(({_value} - {_n}) / ({_n} * 2)) * {_n} * 2 - {_n})
 
@@ -69,7 +69,7 @@ function ping_pong(value: number, n: number = 1) :: number:
 #>
 #> @param value The input number
 #> @return A number between 0 and 1
-function fract(value: number) :: number:
+function fract(value: number) -> number:
 	return {_value} - floor({_value})
 
 #> Wraps a number around a range [low, high].
@@ -80,7 +80,7 @@ function fract(value: number) :: number:
 #> @param low The lower bound (inclusive).
 #> @param high The upper bound (exclusive).
 #> @return The wrapped number within [low, high].
-function wrap(value: number, low: number, high: number) :: number:
+function wrap(value: number, low: number, high: number) -> number:
 	return mod(({_value} - {_low}), ({_high} - {_low})) + {_low}
 
 #> Converts an integer to its hexadecimal string representation.
@@ -90,7 +90,7 @@ function wrap(value: number, low: number, high: number) :: number:
 #>
 #> @param value The integer to convert.
 #> @return The hexadecimal string.
-function hex(value: integer) :: string:
+function hex(value: integer) -> string:
 	return "0" if {_value} <= 0
 	return {-mib_lib::math::hex}[{_value}] if {_value} < 16
 	return hex({_value} >> 4) + {-mib_lib::math::hex}[{_value} & 0xF]
@@ -102,26 +102,26 @@ function hex(value: integer) :: string:
 #>
 #> @param value The input angle in degrees, can be negative / positive
 #> @return The closest angle among [0, 90. 180, 270]
-function closest_angle_value(value: number) :: integer:
+function closest_angle_value(value: number) -> integer:
 	return clamp(round({_x} / 90), 0, 3) * 90
 
-function vec(x: number, y: number, z: number) :: vector:
+function vec(x: number, y: number, z: number) -> vector:
 	return vector({_x}, {_y}, {_z})
 
-function vec(n: number) :: vector:
+function vec(n: number) -> vector:
 	return vector({_n}, {_n}, {_n})
 
-function x(n: number) :: vector:
+function x(n: number) -> vector:
 	return vector({_n}, 0, 0)
 
-function y(n: number) :: vector:
+function y(n: number) -> vector:
 	return vector(0, {_n}, 0)
 
-function z(n: number) :: vector:
+function z(n: number) -> vector:
 	return vector(0, 0, {_n})
 
-function noise(generator: object, vector: vector) :: number:
+function noise(generator: object, vector: vector) -> number:
 	return sknoise value of {_generator} at (x of {_vector}), (y of {_vector}), (z of {_vector})
 
-function noise_at(generator: object, location: location) :: number:
+function noise_at(generator: object, location: location) -> number:
 	return sknoise value of {_generator} at {_location}

--- a/common/NumberFormat.sk
+++ b/common/NumberFormat.sk
@@ -25,7 +25,7 @@ using script reflection
 #>**scientific**:
 #>- 1234 → "1.23E3"
 #>- 1234567 → "1.23E6"
-function number_format(number: number, format: string = "small") :: string:
+function number_format(number: number, format: string = "small") -> string:
 	if ({_number} < 1000):
 		return "%{_number}%"
 
@@ -58,24 +58,24 @@ function number_format(number: number, format: string = "small") :: string:
 #> Example: suffix_at(3) = "B" (for Billion)
 #>
 #>
-function suffix_at(tier: integer, format: string = "small") :: string:
+function suffix_at(tier: integer, format: string = "small") -> string:
 	return {-mib_lib::suffixes::%{_format}%::%{_tier}%}
 
 #> Returns whether a string is a valid format
 #>
 #> @param format The format to compare
 #> @return Returns true if it is a valid format.
-function is_format_valid(format: string) :: boolean:
+function is_format_valid(format: string) -> boolean:
 	return whether {_format} is any of all_formats()
 
 #> Returns all valid formats of the number_format function
 #>
 #> @return All the formats
-function all_formats() :: strings:
+function all_formats() -> strings:
 	return ("small", "big", "scientific" and "full")
 
 #> Creates a number with assured amount of decimal places.
-function with_zeros(number: number, zeros: integer) :: string:
+function with_zeros(number: number, zeros: integer) -> string:
     if {_number} = floor({_number}):
         return join ("%{_number}%.", ("0" repeated {_zeros} times))
     return "%{_number}%"

--- a/common/Particle.sk
+++ b/common/Particle.sk
@@ -1,2 +1,0 @@
-function a_particle(at: location, particles: objects):
-    draw {_particles::*} at {_at}

--- a/common/PlayerHead.sk
+++ b/common/PlayerHead.sk
@@ -7,7 +7,7 @@
 #>
 #> @param texture The texture of the head
 #> @return The head
-function new_player_head(texture: string) :: item:
+function new_player_head(texture: string)->item:
     return player head with nbt (nbt from "{""minecraft:profile"":{id:[I;0,0,0,0],properties:[{name:""textures"",value:""%{_texture}%""}]}}")
 
 #> Loads a head under an ID, and names the head to the ID

--- a/common/Position.sk
+++ b/common/Position.sk
@@ -2,15 +2,13 @@
 #
 # This module requires the following other modules: NONE
 
-using for loops
-
 #> Gets all of the points on a circle given a radius
 #> Use over filtering all blocks in a radius for a 2d check.
 #> 5x more performant than a 3d with filter.
 #>
 #> @param radius The radius of the circle
 #> @return points The vectors corrosponding to the offsets
-function all_in_circle(radius: integer) :: vectors:
+function all_in_circle(radius: integer) -> vectors:
 	set {_radius} to abs({_radius})
 	set {_i_radius} to {_radius} * -1
 	set {_r_square} to {_radius} ^ 2
@@ -28,7 +26,7 @@ function all_in_circle(radius: integer) :: vectors:
 #>
 #> @param radius The radius of the circle
 #> @param points The vectors corrosponding to the offsets
-function all_in_circle_fast(radius: integer) :: vectors:
+function all_in_circle_fast(radius: integer) -> vectors:
 	suppress variable save warnings
 	if {-mib_lib::position::radius::%{_radius}%} is set:
 		return ...{-mib_lib::position::radius::%{_radius}%}
@@ -56,22 +54,22 @@ function transition_to(player: player, location: location):
 	sleep_effect({_player})
 	teleport({_player}, {_location})
 
-function location(vector: vector) :: location:
+function location(vector: vector) -> location:
 	return location((x of {_vector}), (y of {_vector}), (z of {_vector}))
 
-function location(x: number, y: number, z: number, ya: number, pi: number) :: location:
+function location(x: number, y: number, z: number, ya: number, pi: number) -> location:
 	return location({_x}, {_y}, {_z}, world "world", {_ya}, {_pi})
 
-function with_yaw(location: location, yaw: number) :: location:
+function with_yaw(location: location, yaw: number) -> location:
 	set yaw of {_location} to {_yaw}
 	return {_location}
 
-function with_pitch(location: location, pitch: number) :: location:
+function with_pitch(location: location, pitch: number) -> location:
 	set pitch of {_location} to {_pitch}
 	return {_location}
 
-function with_yaw_pitch(location: location, pitch: number, yaw: number) :: location:
+function with_yaw_pitch(location: location, pitch: number, yaw: number) -> location:
 	return with_yaw(with_pitch({_location}, {_pitch}), {_yaw})
 
-function flatten(location: location) :: location:
+function flatten(location: location) -> location:
 	return with_yaw(with_pitch({_location}, 0), 0)

--- a/common/SNBT.sk
+++ b/common/SNBT.sk
@@ -1,4 +1,5 @@
-function read_snbt_file(path: string) :: nbt:
+
+function read_snbt_file(path: string) -> nbt:
     set {_file_contents} to join file_read_lines({_path}) with ""
     return nbt from {_file_contents}
 
@@ -12,7 +13,7 @@ import:
 #>
 #> @param path The path to the file being read
 #> @return A list of lines as strings, or <none> if the file was not found.
-function file_read_lines(path: string) :: strings:
+function file_read_lines(path: string) -> strings:
     set {_file} to new File({_path})
     if ({_file}.exists() = false):
         error("File %{_path}% was not found.")

--- a/common/Set.sk
+++ b/common/Set.sk
@@ -1,7 +1,6 @@
-using for loops
 
 # Mimics a set, taking in a list and returning a keyed list where each value is it's index.
-function set(in: objects) :: objects:
+function set(in: objects) -> objects:
     for {_object} in {_in::*}:
         set {_out::%{_object}%} to {_object}
     return keyed {_out::*}

--- a/common/Sound.sk
+++ b/common/Sound.sk
@@ -5,7 +5,6 @@
 # This module requires the following other modules: NONE
 
 using script reflection
-using for loops
 
 # STRUCTS
 
@@ -61,7 +60,7 @@ function sound(players: players, sound: Sound struct):
 		stop
 	play sound ({_sound}->id) with seed ({_sound}->seed) in ({_sound}->category) at volume ({_sound}->volume) at pitch ({_sound}->pitch) to {_players::*} at {_sound}->at
 
-function a_generator_at(generator: SoundGenerator struct, at: location, audience: players = all players) :: Sound struct:
+function a_generator_at(generator: SoundGenerator struct, at: location, audience: players = all players) -> Sound struct:
 	set {_generator} to struct copy of {_generator}
 	set {_generator}->at to {_at}
 	set {_sound} to sound_from({_generator})
@@ -72,7 +71,7 @@ function a_generator_at(generator: SoundGenerator struct, at: location, audience
 		sound({_audience::*}, {_sound})
 		wait {_generator}->time_between
 
-function sound_from(generator: SoundGenerator struct) :: Sound struct:
+function sound_from(generator: SoundGenerator struct) -> Sound struct:
 	return Sound struct instance:
 		id: random element of {_generator}->id
 		volume: {_generator}->volume + rnd({_generator}->random_volume)
@@ -87,7 +86,7 @@ function sound_from(generator: SoundGenerator struct) :: Sound struct:
 #> @param seed (Optional) Seed for variations of sounds, default random which is <none>
 #> @param category (Optional) Sound category, default master
 #> @param offset (Optional)
-function a_sound(sound_id: string, volume: number = 1, pitch: number = 1, seed: integer = {_}, category: sound category = {_}, offset: timespan = {_}) :: Sound struct:
+function a_sound(sound_id: string, volume: number = 1, pitch: number = 1, seed: integer = {_}, category: sound category = {_}, offset: timespan = {_}) -> Sound struct:
 	return Sound struct instance:
 		id: {_sound_id}
 		volume: {_volume}
@@ -101,7 +100,7 @@ function a_sound(sound_id: string, volume: number = 1, pitch: number = 1, seed: 
 #> @param pattern SoundPattern struct to use
 #> @param beats A list of beat positions (numbers) to schedule pattern play timings
 #> @return The created PatternLayer struct
-function a_pattern_layer(pattern: SoundPattern struct, beats: numbers) :: PatternLayer struct:
+function a_pattern_layer(pattern: SoundPattern struct, beats: numbers) -> PatternLayer struct:
 	set {_layer} to PatternLayer struct instance:
 		pattern: {_pattern}
 		beats: {_beats::*}

--- a/common/StateMachine.sk
+++ b/common/StateMachine.sk
@@ -1,5 +1,4 @@
 
-using for loops
 using script reflection
 
 import:
@@ -24,7 +23,7 @@ struct StateMachine:
 
 	dynamic state_name: string = this->state->name
 
-function a_machine(transitions: Transition structs, state: State struct, context: object, debug: boolean = false) :: StateMachine struct:
+function a_machine(transitions: Transition structs, state: State struct, context: object, debug: boolean = false) -> StateMachine struct:
 
 	set {_transition_map} to new HashMap()
 
@@ -52,20 +51,20 @@ function a_machine(transitions: Transition structs, state: State struct, context
 	run ({_state}->start) with args "initialize", {_machine}
 	return {_machine}
 
-function a_transition(event: string, from: State struct, to: State struct) :: Transition struct:
+function a_transition(event: string, from: State struct, to: State struct) -> Transition struct:
 	return Transition struct instance:
 		event: {_event}
 		from: {_from}
 		to: {_to}
 
-function a_state(name: string, start: function, tick: function, end: function) :: State struct:
+function a_state(name: string, start: function, tick: function, end: function) -> State struct:
 	return State struct instance:
 		name: {_name}
 		start: {_start}
 		tick: {_tick}
 		end: {_end}
 
-function transition_of(machine: StateMachine struct, event: string) :: Transition struct:
+function transition_of(machine: StateMachine struct, event: string) -> Transition struct:
     set {_state} to {_machine}->state
 
     if {_machine}->transitions.containsKey({_state}->name) is false:
@@ -75,7 +74,7 @@ function transition_of(machine: StateMachine struct, event: string) :: Transitio
 
     return {_by_event}.get({_event})
 
-function trigger_event(machine: StateMachine struct, event: string) :: boolean:
+function trigger_event(machine: StateMachine struct, event: string) -> boolean:
 	set {_transition} to transition_of({_machine}, {_event})
 	if {_transition} is not set:
 		return false

--- a/common/Struct.sk
+++ b/common/Struct.sk
@@ -1,4 +1,3 @@
-using for loops
 
 condition:
     patterns:
@@ -52,7 +51,7 @@ struct property field %string%:
     reset:
         expr-1.resetFieldValue(java field expr-2 of expr-1, event)
 
-local function template_field(field: object) :: TemplateField struct:
+local function template_field(field: object) -> TemplateField struct:
     return TemplateField struct instance:
         java_field: {_field}
         name: {_field}.name()

--- a/common/Theme.sk
+++ b/common/Theme.sk
@@ -1,3 +1,4 @@
+
 on tab complete of "skript" and "sk":
 	set {_t::*} to tab completions where [input does not contain "\.git"]
 	set tab completions for position 2 to {_t::*}

--- a/common/Tickrate.sk
+++ b/common/Tickrate.sk
@@ -1,3 +1,4 @@
+
 import:
     net.minecraft.network.protocol.game.ClientboundTickingStatePacket
 

--- a/source/chat.sk
+++ b/source/chat.sk
@@ -1,3 +1,4 @@
+
 import:
     java.util.concurrent.atomic.AtomicInteger
 
@@ -7,8 +8,6 @@ options:
     chat_white: rgb(210, 215, 220)
     spacing: px(2)
     date_format: "HH:mm"
-
-using for loops
 
 struct Message:
     const sender: string
@@ -27,21 +26,21 @@ on chat:
     cancel event
     chat_handle(player, message)
 
-function format_player_header(player: player, color: color = {@white}) :: textcomponent:
+function format_player_header(player: player, color: color = {@white}) -> textcomponent:
     set {_head} to object text component with player head of {_player}
     set {_name} to colored_component(name of {_player}, {_color})
     return merge components px(1), {_head}, px(3), {_name}
 
-function format_timestamp(date: date) :: textcomponent:
+function format_timestamp(date: date) -> textcomponent:
     return colored_component({_date} formatted as {@date_format}, {@gray})
 
-function format_header(player: player, date: date) :: textcomponent:
+function format_header(player: player, date: date) -> textcomponent:
     return merge components format_timestamp(now), px(4), format_player_header({_player})
 
-function message_assemble_components(header: textcomponent, message: textcomponent, button: textcomponent = {_}, delete_button: textcomponent = {_}) :: textcomponent:
+function message_assemble_components(header: textcomponent, message: textcomponent, button: textcomponent = {_}, delete_button: textcomponent = {_}) -> textcomponent:
     return merge components {_header}, px(3), {_button}, px(2), component_from_id("arrow_right"), px(3), {_message}, px(2), {_delete_button}
 
-function underlined_naughty_words(result: FilterResult struct) :: textcomponent:
+function underlined_naughty_words(result: FilterResult struct) -> textcomponent:
     for {_text} in ({_result}->matched text):
         set {_c} to colored_component({_text}, rgb(255, 0, 0))
         set underline format of {_c} to true
@@ -100,7 +99,7 @@ function reply_state_start(player: player, target: player):
     set {-reply_state::%{_player}%} to a_promise(1 minute)
     feedback_reply_started({_player}, {_target})
 
-function reply_state(player: player) :: future:
+function reply_state(player: player) -> future:
     return {-reply_state::%{_player}%} 
 
 function reply_state_complete(player: player, message: message struct):
@@ -123,18 +122,18 @@ local function reply_handle(sender: player, target: player, reply_history: textc
     chat_handle({_sender}, {_message}->message, {_reply_history::*})
 
 # get the last message sent (for comparison)
-local function message_last() :: message struct:
+local function message_last() -> message struct:
     return 2nd last element of {-message::*}
 
 # retrieve a message by ID
-local function message_get(id: integer) :: message struct:
+local function message_get(id: integer) -> message struct:
     return {-message::%{_id}%}
 
-local function message_current() :: message struct:
+local function message_current() -> message struct:
     return {-message::%{-message_counter}.intValue()%}
 
 # store a message and return its ID
-local function player_message_save(player: player, text: string) :: message struct:
+local function player_message_save(player: player, text: string) -> message struct:
     set {_id} to {-message_counter}.incrementAndGet()
     set {-message::%{_id}%} to Message struct instance:
         message: {_text}

--- a/source/commands.sk
+++ b/source/commands.sk
@@ -1,3 +1,4 @@
+
 function load_commands():
 	set {-commands::*} to keyed set(all script commands)
 

--- a/source/components/animation.sk
+++ b/source/components/animation.sk
@@ -1,5 +1,5 @@
+
 using script reflection
-using for loop
 
 function load_animation_components():
     save_animation_component("flash", AnimationComponent struct instance):
@@ -17,7 +17,7 @@ struct AnimationComponent:
 function save_animation_component(id: string, component: AnimationComponent struct):
     set {-animation_component::%{_id}%} to {_component}
 
-function a_animation_component(id: string, location: location, options: struct) :: AnimationComponent struct:
+function a_animation_component(id: string, location: location, options: struct) -> AnimationComponent struct:
     set {_component} to struct copy of {-animation_component::%{_id}%}
     set {_component}->end to a_promise()
     set {_component}->loc to {_location}
@@ -31,7 +31,7 @@ struct FlashOptions:
 function break_sounds_in_radius(location: location, radius: number):
     loop shuffled (all_in_circle_fast(({_radius})) mapped with [block at ({_location} ~ input)]):
         play sound (break sound of type of loop-value) with volume 0.02 at loop-value
-        draw 10 (block) using (type of loop-value) at loop-value ~ y(1) with delta y(1) with extra 1
+        # draw 10 (block) using (type of loop-value) at loop-value ~ y(1) with delta y(1) with extra 1
         make (players) see damage of (loop-value) as rnd(0.3, 0.7) from random integer between 1 and 10000
         wait 1 tick if mod(loop-counter, 10) = 0
 
@@ -78,10 +78,10 @@ function flash_animation(component: AnimationComponent struct):
 
     play sound "entity.splash_potion.break" with seed 1 with volume 0.4 with pitch 2 at ({_component}->loc)
     play sound "minecraft:item.trident.return" with seed 1 with volume 0.4 with pitch 1 at ({_component}->loc)
-    draw 50 effect using particleSpell(rgb(255,255,255), 0.4) at ({_component}->loc) with delta vec(1, 0, 1) with extra 1
+    # draw 50 effect using particleSpell(rgb(255,255,255), 0.4) at ({_component}->loc) with delta vec(1, 0, 1) with extra 1
     break_sounds_in_radius({_component}->loc ~ y(-1), {_o}->size / 10)
 
-    draw 10 firework at {_component}->loc with delta vec(1) with extra 0.3
+    # draw 10 firework at {_component}->loc with delta vec(1) with extra 0.3
     complete {_component}->end with {_e::interaction}
     wait 1 tick
     kill {_e::*}
@@ -111,5 +111,3 @@ function a_star(location: location, size: number, count: integer, color: string 
         set opacity of {_e} to {_easing} * 100 + 100
         wait 1 tick
     kill {_e}
-
-    

--- a/source/components/animation.sk
+++ b/source/components/animation.sk
@@ -29,10 +29,13 @@ struct FlashOptions:
     size: number
 
 function break_sounds_in_radius(location: location, radius: number):
-    loop shuffled (all_in_circle_fast(({_radius})) mapped with [block at ({_location} ~ input)]):
-        play sound (break sound of type of loop-value) with volume 0.02 at loop-value
-        # draw 10 (block) using (type of loop-value) at loop-value ~ y(1) with delta y(1) with extra 1
-        make (players) see damage of (loop-value) as rnd(0.3, 0.7) from random integer between 1 and 10000
+    for {_block} in shuffled (all_in_circle_fast(({_radius})) mapped with [block at ({_location} ~ input)]):
+        set {_type} to type of {_block}
+
+        play sound (break sound of {_type}) with volume 0.02 at {_block}
+        draw vfx_block_break({_type}) at ({_block} ~ y(1)) 
+        make (players) see damage of {_block} as rnd(0.3, 0.7) from rndi(10000)
+
         wait 1 tick if mod(loop-counter, 10) = 0
 
 function flash_animation(component: AnimationComponent struct):
@@ -78,10 +81,10 @@ function flash_animation(component: AnimationComponent struct):
 
     play sound "entity.splash_potion.break" with seed 1 with volume 0.4 with pitch 2 at ({_component}->loc)
     play sound "minecraft:item.trident.return" with seed 1 with volume 0.4 with pitch 1 at ({_component}->loc)
-    # draw 50 effect using particleSpell(rgb(255,255,255), 0.4) at ({_component}->loc) with delta vec(1, 0, 1) with extra 1
+    draw 50 rgb(255,255,255) effect particle of power 0.4 with offset vec(1, 0, 1) with extra value 1 at ({_component}->loc)
     break_sounds_in_radius({_component}->loc ~ y(-1), {_o}->size / 10)
 
-    # draw 10 firework at {_component}->loc with delta vec(1) with extra 0.3
+    draw 10 firework particle with offset vec(1) with extra value 0.3 at {_component}->loc 
     complete {_component}->end with {_e::interaction}
     wait 1 tick
     kill {_e::*}

--- a/source/components/text.sk
+++ b/source/components/text.sk
@@ -1,3 +1,4 @@
+
 options:
     white: rgb(230, 230, 230)
     light_gray: rgb(154, 146, 187)
@@ -15,7 +16,7 @@ options:
 function save_component(id: string, component: textcomponent):
     set {-components::%{_id}%} to {_component}
 
-function component_from_id(id: string) :: textcomponent:
+function component_from_id(id: string) -> textcomponent:
     return {-components::%{_id}%}
 
 function load_components():
@@ -28,58 +29,58 @@ function load_components():
     save_component("unfilled_blood_stone", merge components (wrap_around(colored_component("☠", {@gray}), c("["), c("]"), 0.8), px(1)))
     save_component("bar", colored_component("‘", {@gray}))
 
-function a_real(value: number) :: text component:
+function a_real(value: number) -> text component:
     return component_real({_value}, {@white}, {@plus}, {@negative})
 
-function a_unit(value: number, unit: string) :: text component:
+function a_unit(value: number, unit: string) -> text component:
     return component_unit({_value}, {_unit}, {@white}, {@light_gray})
 
-function a_fraction(numerator: number, denominator: number) :: text component:
+function a_fraction(numerator: number, denominator: number) -> text component:
     return component_fraction({_numerator}, {_denominator}, {@white}, {@light_gray})
 
-function a_percent(value: number) :: text component:
+function a_percent(value: number) -> text component:
     return component_percent({_value}, {@white}, {@light_gray})
 
-function a_angular_brackets(component: textcomponent) :: textcomponent:
+function a_angular_brackets(component: textcomponent) -> textcomponent:
     return wrap_around({_component}, c("{@angular_bracket.l}"), c("{@angular_bracket.r}"), 0.9)
 
-function a_rank(rank: string, color: color) :: textcomponent:
+function a_rank(rank: string, color: color) -> textcomponent:
     return wrap_around(colored_component(uppercase {_rank}, {_color}), c("["), c("]"), 0.8)
 
-function a_level(level: integer) :: textcomponent:
+function a_level(level: integer) -> textcomponent:
     return a_angular_brackets(colored_component("%{_level}%", yellow))
 
-function a_effect_title(title: string, color: color) :: textcomponent:
+function a_effect_title(title: string, color: color) -> textcomponent:
     set {_width} to (50 - (width({_title}) / 3)) / 2
     set {_bar} to a_notch_bar(component_from_id("bar"), component_from_id("bar"), {_width}, {_width})
     return merge components {_bar}, px(4), a_angular_brackets(colored_component({_title}, {_color})), px(4), {_bar}
 
-function a_effect_description(line: textcomponent) :: textcomponent:
+function a_effect_description(line: textcomponent) -> textcomponent:
     set {_component} to merge components px(6), {_line}
     set color format of {_component} to {@white}
     return {_component}
 
-function a_lore(lore: string) :: textcomponent:
+function a_lore(lore: string) -> textcomponent:
     set {_lore} to colored_component("“ %{_lore}% „ ", change_brightness({@gray}, 1.4))
     set italic format of {_lore} to true
     return merge components (px(2), {_lore})
 
-function a_lore_unit(value: number, unit: string) :: textcomponent:
+function a_lore_unit(value: number, unit: string) -> textcomponent:
     return component_unit({_value}, {_unit}, {@lore_unit}, {@lore_unit})
 
-function a_key(id: string) :: textcomponent:
+function a_key(id: string) -> textcomponent:
     set {_key} to keybind component of "key.%{_id}%"
     set color format of {_key} to orange
     return wrap_around({_key}, c("["), c("]"), 0.85)
 
-function a_event(event: string) :: textcomponent:
+function a_event(event: string) -> textcomponent:
     return wrap_around(colored_component("On %{_event}%", orange), c("["), c("]"), 0.85)
 
-function a_notch_bar(component_a: textcomponent, component_b: textcomponent, max: integer, count: integer) :: textcomponent:
+function a_notch_bar(component_a: textcomponent, component_b: textcomponent, max: integer, count: integer) -> textcomponent:
     set {_count} to min({_max}, {_count})
     return merge components (({_count} times) mapped with [{_component_a}], ({_max} - {_count} times) mapped with [{_component_b}])
 
-function a_fancy_notch_bar(component_a: textcomponent, component_b: textcomponent, max: integer, count: integer) :: textcomponent:
+function a_fancy_notch_bar(component_a: textcomponent, component_b: textcomponent, max: integer, count: integer) -> textcomponent:
     set {_count} to min({_max}, {_count})
     set {_a::*} to ({_count} times) mapped with [shift_brightness({_component_a}, 0.8 + input / ({_count} * 2))]
     set {_b::*} to ({_max} - {_count} times) mapped with [{_component_b}]

--- a/source/components/ui_bar.sk
+++ b/source/components/ui_bar.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using reflection
 
 struct UIBar:
@@ -6,7 +6,7 @@ struct UIBar:
     limit: Bindable struct
     debounce: date = now
 
-function a_ui_bar(value: object, limit: object, extension: struct, callbacks: functions) :: UIBar struct:
+function a_ui_bar(value: object, limit: object, extension: struct, callbacks: functions) -> UIBar struct:
     set {_bar} to UIBar struct instance
 
     create section with {_bindable}, {_change_value} stored in {_renderer}:

--- a/source/feedback.sk
+++ b/source/feedback.sk
@@ -1,4 +1,3 @@
-using for loops
 
 function load_feedback():
     for {_type} in ("bug", "report", "suggestion"):

--- a/source/item/attack_types.sk
+++ b/source/item/attack_types.sk
@@ -1,3 +1,4 @@
+
 using script reflection
 
 struct AttackType:
@@ -15,14 +16,14 @@ function load_attack_types():
     set {-attack_type::charge} to a_attack_type("charge", "crossbow", 0.6 second, "charge")
     set {-attack_type::shot} to a_attack_type("shot", "spyglass", 0.4 second, "shot")
 
-function a_attack_type(id: string, animation: string, duration: timespan, type_handler_id: string) :: AttackType struct:
+function a_attack_type(id: string, animation: string, duration: timespan, type_handler_id: string) -> AttackType struct:
     return AttackType struct instance:
         id: {_id}
         animation: {_animation}
         duration: {_duration}
         handler: function "attack_handler" from script "source/player/combat/types/%{_type_handler_id}%.sk"
 
-function attack_type(id: string) :: AttackType struct:
+function attack_type(id: string) -> AttackType struct:
     return {-attack_type::%{_id}%}
 
 function attack_handler(ctx: CombatContext struct, attack: string):

--- a/source/item/description.sk
+++ b/source/item/description.sk
@@ -1,2 +1,3 @@
-function render_description(item: Item struct, source: string) :: integer:
+
+function render_description(item: Item struct, source: string) -> integer:
     return append_lines({_item}, a_lore({_source}))

--- a/source/item/extension.sk
+++ b/source/item/extension.sk
@@ -1,2 +1,3 @@
+
 struct Ratio:
     limit: object

--- a/source/item/hotkey.sk
+++ b/source/item/hotkey.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using script reflection
 
 function handle_hotkey_event(player: player, event: string, item: item = {_}):

--- a/source/item/item.sk
+++ b/source/item/item.sk
@@ -1,5 +1,5 @@
+
 using script reflection
-using for loops
 
 import:
     java.util.HashMap
@@ -22,10 +22,10 @@ function delete_item(item: Item struct):
     set slot {_item}->slot of {_item}->owner to air 
     delete {_item}
 
-function item(item: item) :: Item struct:
+function item(item: item) -> Item struct:
     return {-item::%string tag "uuid" of custom nbt of {_item}%}
 
-function a_blank_item(model: string, name: textcomponent, uuid: string) :: item:
+function a_blank_item(model: string, name: textcomponent, uuid: string) -> item:
     set {_item} to gunpowder
     set string tag "uuid" of custom nbt of {_item} to {_uuid}
     set item model of {_item} to {_model}

--- a/source/item/item_creator.sk
+++ b/source/item/item_creator.sk
@@ -1,7 +1,7 @@
-using reflection
-using for loops
 
-function create_item(nbt: nbt) :: Item struct:
+using reflection
+
+function create_item(nbt: nbt) -> Item struct:
     set {_uuid} to random uuid
     set {_level} to int tag "level" of {_nbt}
     set {_rank} to string tag "rank" of {_nbt}
@@ -25,13 +25,13 @@ function give_item_to(item: Item struct, player: player):
     set slot {_item}->slot of {_player} to {_item}->base
     render_lore({_item})
 
-function deserialize_stats(source: nbt) :: objects:
+function deserialize_stats(source: nbt) -> objects:
     set {_compound::*} to keyed (compound_as_list(compound tag "stats[0]" of {_source}))
     set {_stats::*} to {_compound::*} mapped with [a_stat(stat_type(input index), input)]
     sort {_stats::*} by input->extension->order
     return {_stats::*}
 
-function deserialize_special_effects(source: nbt) :: objects:
+function deserialize_special_effects(source: nbt) -> objects:
     set {_compound::*} to (string list tag "special_effects" of {_source})
     return {_compound::*} mapped with [a_special_effect(special_effect_type(input))]
 

--- a/source/item/ranks.sk
+++ b/source/item/ranks.sk
@@ -1,3 +1,4 @@
+
 function load_ranks():
     set {-rank::basic} to a_rank("basic", rgba(154, 146, 187))
     set {-rank::rare} to a_rank("rare", rgba(114, 120, 230))

--- a/source/item/renderer.sk
+++ b/source/item/renderer.sk
@@ -1,5 +1,5 @@
+
 using script reflection
-using for loops
 
 function render_lore(item: Item struct):
     set {_source} to {_item}->source
@@ -18,7 +18,7 @@ function render_lore(item: Item struct):
         attach_special_effect({_item}, {_effect})
         set {_item}->render_depth to render_special_effect({_item}, {_effect})
 
-function append_lines(item: Item struct, components: textcomponents) :: integer:
+function append_lines(item: Item struct, components: textcomponents) -> integer:
     for {_component} in {_components::*}:
         set_line({_item}->owner, {_item}->slot, {_item}->render_depth, {_component})
         add 1 to {_item}->render_depth

--- a/source/item/slot_manager.sk
+++ b/source/item/slot_manager.sk
@@ -1,3 +1,4 @@
+
 on inventory slot change:
     event-item != 0 airs
     if player's metadata "slot=%(index of event-slot)%" is not set:

--- a/source/item/special_effect.sk
+++ b/source/item/special_effect.sk
@@ -1,14 +1,14 @@
+
 options:
     path: "source/item/special_effects/"
 
-using for loops
 using script reflection
 
 struct SpecialEffectType:
-    # add() :: extension?
+    # add() -> extension?
     const add: function
 
-    # update(extension) :: textcomponents
+    # update(extension) -> textcomponents
     const update: function
 
 struct SpecialEffect:
@@ -22,10 +22,10 @@ function load_special_effects():
             add: function "add" in script "%{_script}%"
             update: function "update" in script "%{_script}%"
 
-function special_effect_type(id: string) :: SpecialEffectType struct:
+function special_effect_type(id: string) -> SpecialEffectType struct:
     return {-special_effect_type::%{_id}%}
 
-function a_special_effect(type: SpecialEffectType struct) :: SpecialEffect struct:
+function a_special_effect(type: SpecialEffectType struct) -> SpecialEffect struct:
     set {_extension} to result of {_type}->add
     return SpecialEffect struct instance:
         type: {_type}
@@ -35,5 +35,5 @@ function a_special_effect(type: SpecialEffectType struct) :: SpecialEffect struc
 function attach_special_effect(item: Item struct, effect: SpecialEffect struct):
     add {_effect} to {_item}->special_effects
 
-function render_special_effect(item: Item struct, effect: SpecialEffect struct) :: integer:
+function render_special_effect(item: Item struct, effect: SpecialEffect struct) -> integer:
     return append_lines({_item}, {_effect}->components)

--- a/source/item/special_effects/entangle.sk
+++ b/source/item/special_effects/entangle.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using script reflection
 
 struct Entangle:
@@ -8,15 +8,15 @@ struct Entangle:
     cooldown: timespan = 2 seconds
     on_secondary: function = function "on_secondary"
 
-local function add() :: struct:
+local function add() -> struct:
     return Entangle struct instance
 
-local function update(entangle: Entangle struct) :: textcomponents:
+local function update(entangle: Entangle struct) -> textcomponents:
     set {_title} to a_effect_title({_entangle}->name, {_entangle}->color)
     set {_key} to a_event({_entangle}->event)
 
-    set {_text::1} to a_effect_description(merge components {_key}, minimessage from " Shoot")
-    set {_text::2} to a_effect_description(merge components minimessage from "root projectiles into enemies")
+    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Shoot"))
+    set {_text::2} to a_effect_description(merge components (minimessage from "root projectiles into enemies"))
 
     return {_title}, {_text::*}, blank()
 
@@ -25,5 +25,3 @@ local function on_secondary(player: player, entangle: Entangle struct, weapon: I
     set {_root} to a_item_display()
 
     set item of {_root} to (mangrove propagule, firefly bush)
-
-    

--- a/source/item/special_effects/regrowth.sk
+++ b/source/item/special_effects/regrowth.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using script reflection
 
 struct Regrowth:
@@ -10,17 +10,17 @@ struct Regrowth:
     cooldown: timespan = 1 seconds
     on_hit: function = function "on_hit"
 
-local function add() :: struct:
+local function add() -> struct:
     return Regrowth struct instance
 
-local function update(regrowth: Regrowth struct) :: textcomponents:
+local function update(regrowth: Regrowth struct) -> textcomponents:
     set {_title} to a_effect_title({_regrowth}->name, {_regrowth}->color)
     set {_key} to a_event({_regrowth}->event)
     set {_heal} to a_lore_unit({_regrowth}->heal, "hp/s")
     set {_time} to a_lore_unit(seconds of {_regrowth}->duration, "s")
 
-    set {_text::1} to a_effect_description(merge components {_key}, minimessage from " Restores ", {_heal})
-    set {_text::2} to a_effect_description(merge components minimessage from "for ", {_time})
+    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Restores ", {_heal}))
+    set {_text::2} to a_effect_description(merge components (minimessage from "for ", {_time}))
 
     return {_title}, {_text::*}, blank()
 

--- a/source/item/special_effects/spin.sk
+++ b/source/item/special_effects/spin.sk
@@ -27,10 +27,11 @@ local function on_drop(player: player, spin: Spin struct, weapon: Item struct):
     set {_radius} to {_spin}->radius
     set pitch of {_forward} to 0
     change_tickrate({_player}, 0, true)
+    wait 1 tick
     loop 30 times:
         rotate {_forward} around y-axis by ease_out_circle(loop-counter / 30) * 44.6
         set yaw of {_player} to yaw of {_forward}
-        # draw 2 sweep_attack at {_player}'s head ~ {_forward} * 3
+        draw 2 sweep attack particle at {_player}'s head ~ {_forward} * 3
         if mod(loop-counter, 10) = 0:
             set {_entities::*} to ...(world of {_player}).getNearbyEntities({_player}'s head, {_radius}, {_radius}, {_radius})
             for {_entity} in {_entities::*}:

--- a/source/item/special_effects/spin.sk
+++ b/source/item/special_effects/spin.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using script reflection
 
 struct Spin:
@@ -9,17 +9,17 @@ struct Spin:
     cooldown: timespan = 2 seconds
     on_drop: function = function "on_drop"
 
-local function add() :: struct:
+local function add() -> struct:
     return Spin struct instance
 
-local function update(spin: Spin struct) :: textcomponents:
+local function update(spin: Spin struct) -> textcomponents:
     set {_title} to a_effect_title({_spin}->name, {_spin}->color)
     set {_key} to a_key({_spin}->key)
     set {_time} to a_lore_unit(seconds of {_spin}->cooldown, "s")
     set {_radius} to a_lore_unit({_spin}->radius, "m")
-    set {_text::1} to a_effect_description(merge components {_key}, minimessage from " Spins you around and hits")
-    set {_text::2} to a_effect_description(merge components minimessage from "enemies in a radius ", {_radius})
-    set {_text::3} to a_effect_description(merge components minimessage from "shortly ", {_time})
+    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Spins you around and hits"))
+    set {_text::2} to a_effect_description(merge components (minimessage from "enemies in a radius ", {_radius}))
+    set {_text::3} to a_effect_description(merge components (minimessage from "shortly ", {_time}))
     return {_title}, {_text::*}, blank()
 
 local function on_drop(player: player, spin: Spin struct, weapon: Item struct):
@@ -30,7 +30,7 @@ local function on_drop(player: player, spin: Spin struct, weapon: Item struct):
     loop 30 times:
         rotate {_forward} around y-axis by ease_out_circle(loop-counter / 30) * 44.6
         set yaw of {_player} to yaw of {_forward}
-        draw 2 sweep_attack at {_player}'s head ~ {_forward} * 3
+        # draw 2 sweep_attack at {_player}'s head ~ {_forward} * 3
         if mod(loop-counter, 10) = 0:
             set {_entities::*} to ...(world of {_player}).getNearbyEntities({_player}'s head, {_radius}, {_radius}, {_radius})
             for {_entity} in {_entities::*}:

--- a/source/item/special_effects/thunderbolt.sk
+++ b/source/item/special_effects/thunderbolt.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using script reflection
 
 struct Thunderbolt:
@@ -10,17 +10,17 @@ struct Thunderbolt:
     amount: integer = 3
     on_drop: function = function "on_drop"
 
-local function add() :: struct:
+local function add() -> struct:
     return Thunderbolt struct instance
 
-local function update(thunderbolt: Thunderbolt struct) :: textcomponents:
+local function update(thunderbolt: Thunderbolt struct) -> textcomponents:
     set {_title} to a_effect_title({_thunderbolt}->name, {_thunderbolt}->color)
     set {_key} to a_key({_thunderbolt}->key)
     set {_amount} to a_lore_unit({_thunderbolt}->amount, "x")
     set {_radius} to a_lore_unit({_thunderbolt}->radius, "m")
-    set {_text::1} to a_effect_description(merge components {_key}, minimessage from " Casts thunderbolts ", {_amount})
-    set {_text::2} to a_effect_description(merge components minimessage from "that drop down and create a")
-    set {_text::3} to a_effect_description(merge components minimessage from "splash ", {_radius})
+    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Casts thunderbolts ", {_amount}))
+    set {_text::2} to a_effect_description(merge components (minimessage from "that drop down and create a"))
+    set {_text::3} to a_effect_description(merge components (minimessage from "splash ", {_radius}))
     return {_title}, {_text::*}, blank()
 
 local function on_drop(player: player, thunderbolt: Thunderbolt struct, weapon: Item struct):
@@ -38,19 +38,21 @@ function shoot_thunderbolt(player: player, weapon: Item struct, direction: vecto
     set {_head} to {_player}'s head
     set {_ray} to (raytrace from {_head} along {_direction} with max distance {_range} while ignoring passable blocks)
     set {_location} to (raytrace hit block of {_ray}) ? block at ({_head} ~ {_direction} * {_range})
+
     set {_line} to line in direction {_direction} and length {_range}
-    draw shape {_line} at {_head}:
-        set event-shape's particle to dust color transition particle using dustTransition(rgb(255,255,255), rgb(100,150,240), 1)
-    loop particle locations of {_line} centered at {_head}:
-        draw 5 of trail particle using trail(loop-value, white, 5 ticks) at loop-value with delta vec(0.1)
-    draw 30 dust using rgb(20, 60, 200) at {_location} with delta vec(0.2) with extra 0.3
+
+    set particle of {_line} to white dust particle that transitions to rgb(100,150,240)
+    draw shape {_line} at {_head}
+
+    draw 30 of rgb(20, 60, 200) dust particle with offset of vec(0.2) with extra value of 0.3 at {_location}
+
     a_star({_location}, 5, 10)
+
     set {_ray} to (raytrace from {_location} along y(-1) while ignoring passable blocks while ignoring all entitytypes)
     set {_line} to line from {_location} to (raytrace hit location of {_ray})
     draw shape {_line}:
-        set event-shape's particle to dust color transition particle using dustTransition(rgb(255,255,255), rgb(100,150,240), 1)
-    loop particle locations of {_line} centered at {_location}:
-        draw 5 of trail particle using trail(loop-value, white, 5 ticks) at loop-value with delta vec(0.1)
+        set event-shape's particle to white dust particle that transitions to rgb(100,150,240)
+
     set {_component} to a_animation_component("flash", (raytrace hit block of {_ray}) ~ y(0.5), FlashOptions struct instance):
         size: {_size}
     wait for future {_component}->end and store the result in {_interaction}
@@ -62,4 +64,3 @@ function shoot_thunderbolt(player: player, weapon: Item struct, direction: vecto
         process_stats({_ctx}, "pre_hit")
         set {_ctx}->victim to {_entity}
         on_hit({_ctx})
-    

--- a/source/item/special_effects/thunderbolt.sk
+++ b/source/item/special_effects/thunderbolt.sk
@@ -9,6 +9,8 @@ struct Thunderbolt:
     radius: number = 3.5
     amount: integer = 3
     on_drop: function = function "on_drop"
+    dark_particle: particle = (30 rgb(20, 60, 200) dust particle with offset vec(0.2) with extra value 0.3)
+    light_particle: particle = (white dust particle that transitions to rgb(100,150,240))
 
 local function add() -> struct:
     return Thunderbolt struct instance
@@ -36,25 +38,33 @@ local function on_drop(player: player, thunderbolt: Thunderbolt struct, weapon: 
 function shoot_thunderbolt(player: player, weapon: Item struct, direction: vector, size: number, range: number):
 
     set {_head} to {_player}'s head
+
     set {_ray} to (raytrace from {_head} along {_direction} with max distance {_range} while ignoring passable blocks)
+
     set {_location} to (raytrace hit block of {_ray}) ? block at ({_head} ~ {_direction} * {_range})
 
     set {_line} to line in direction {_direction} and length {_range}
 
-    set particle of {_line} to white dust particle that transitions to rgb(100,150,240)
-    draw shape {_line} at {_head}
-
-    draw 30 of rgb(20, 60, 200) dust particle with offset of vec(0.2) with extra value of 0.3 at {_location}
+    for {_particle} in vfx_thunder_bolt():
+        set particle of {_line} to {_particle}
+        draw shape {_line} at {_head}
+        draw {_particle} at {_location}
 
     a_star({_location}, 5, 10)
+    wait 1 tick
 
     set {_ray} to (raytrace from {_location} along y(-1) while ignoring passable blocks while ignoring all entitytypes)
     set {_line} to line from {_location} to (raytrace hit location of {_ray})
-    draw shape {_line}:
-        set event-shape's particle to white dust particle that transitions to rgb(100,150,240)
+
+    for {_particle} in vfx_thunder_bolt():
+        
+        set particle of {_line} to {_particle}
+        draw {_particle} at {_location}
+        draw shape {_line}
 
     set {_component} to a_animation_component("flash", (raytrace hit block of {_ray}) ~ y(0.5), FlashOptions struct instance):
         size: {_size}
+
     wait for future {_component}->end and store the result in {_interaction}
     
     set {_entities::*} to ...(world of {_interaction}).getNearbyEntities({_interaction}.getBoundingBox())

--- a/source/item/stat.sk
+++ b/source/item/stat.sk
@@ -1,7 +1,7 @@
+
 options:
     path: "source/item/stats/"
 
-using for loops
 using script reflection
 
 # (behavior definition)
@@ -9,7 +9,7 @@ using script reflection
 struct StatType:
     id: string
 
-    # add(stat) :: extension?
+    # add(stat) -> extension?
     const add: function
     
     # remove(stat)
@@ -55,21 +55,21 @@ function load_stat_types():
             tick: function "tick" in script "%{_script}%"
         run function "load" in script "%{_script}%"
 
-function stat_type(id: string) :: StatType struct:
+function stat_type(id: string) -> StatType struct:
     return {-stat_type::%{_id}%}
 
-function stat(item: Item struct, type: StatType struct) :: Stat struct:
+function stat(item: Item struct, type: StatType struct) -> Stat struct:
     if {_item}->stats.containsKey({_type}) = false:
         stop
     return {_item}->stats.get({_type})
 
-function bindable_stat(item: Item struct, type: StatType struct) :: Bindable struct:
+function bindable_stat(item: Item struct, type: StatType struct) -> Bindable struct:
     return stat({_item}, {_type})->bindable
 
 function set_stat(item: Item struct, type: StatType struct, value: object):
     set bindable_stat({_item}, {_type})'s value to {_value}
 
-function a_stat(type: StatType struct, value: object) :: Stat struct:
+function a_stat(type: StatType struct, value: object) -> Stat struct:
     set {_stat} to Stat struct instance:
         type: {_type}
 
@@ -80,7 +80,7 @@ function a_stat(type: StatType struct, value: object) :: Stat struct:
     set {_stat}->bindable to a_bindable({_value}, a_stat_renderer({_stat}))
     return {_stat}
 
-function a_stat_renderer(stat: Stat struct) :: section:
+function a_stat_renderer(stat: Stat struct) -> section:
 
     set {_item} to {_stat}->item
     set {_update} to {_stat}->type->update
@@ -96,7 +96,7 @@ function a_stat_renderer(stat: Stat struct) :: section:
 
     return {_lore_renderer}
 
-function render_stat(item: Item struct, stat: Stat struct) :: integer:
+function render_stat(item: Item struct, stat: Stat struct) -> integer:
     set {_stat}->depth to {_item}->render_depth
     trigger_update({_stat}->bindable, {_stat}->current)
     return {_item}->render_depth + 1

--- a/source/item/stat_field.sk
+++ b/source/item/stat_field.sk
@@ -1,11 +1,12 @@
+
 struct StatFieldBuilder:
     const emoji: string
     const name: string
     const color: color
     const extra: number = 0
 
-function a_stat_field(builder: StatFieldBuilder struct) :: textcomponent:
+function a_stat_field(builder: StatFieldBuilder struct) -> textcomponent:
     return colored_component(merge components ((minimessage from {_builder}->emoji, px({_builder}->extra + 3), minimessage from {_builder}->name, component(":"))), {_builder}->color)
 
-function a_filled_stat_field(stat_field: string, value: object) :: textcomponent:
+function a_filled_stat_field(stat_field: string, value: object) -> textcomponent:
     return merge components ((component_from_id("stat:%{_stat_field}%"), px(2), colored_component({_value}, rgb(240, 240, 240))))

--- a/source/item/stats/accuracy.sk
+++ b/source/item/stats/accuracy.sk
@@ -1,10 +1,11 @@
+
 using script reflection
 
 struct Accuracy:
     order: integer = 7
     pre_hit: function = function "pre_hit"
 
-local function add(stat: Stat struct) :: Accuracy struct:
+local function add(stat: Stat struct) -> Accuracy struct:
     return Accuracy struct instance
 
 local function pre_hit(ctx: CombatContext struct, stat: Stat struct):
@@ -18,5 +19,5 @@ local function load():
         name: "Accuracy"
         extra: 1
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     return a_filled_stat_field("accuracy", a_percent({_stat}->current))

--- a/source/item/stats/attack_width.sk
+++ b/source/item/stats/attack_width.sk
@@ -1,10 +1,11 @@
+
 using script reflection
 
 struct AttackWidth:
     order: integer = 9
     pre_hit: function = function "pre_hit"
 
-local function add(stat: Stat struct) :: AttackWidth struct:
+local function add(stat: Stat struct) -> AttackWidth struct:
     return AttackWidth struct instance
 
 local function pre_hit(ctx: CombatContext struct, stat: Stat struct):
@@ -17,5 +18,5 @@ local function load():
         name: "Attack Width"
         extra: 3
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     return a_filled_stat_field("attack_width", a_unit({_stat}->current, "m"))

--- a/source/item/stats/blood_stone.sk
+++ b/source/item/stats/blood_stone.sk
@@ -61,12 +61,6 @@ local function pulse(orb: BloodStoneOrb struct):
         set interaction scale of {_orb}->interaction to {_orb}->scale
         wait 1 tick
 
-local function dust(orb: BloodStoneOrb struct, n: integer = 10):
-    # draw {_n} dust using dustOption(rgb(160, 48, 48), 1.4) at ({_orb}->location ~ random vector / 5) with offset (random vector) with extra 0.05
-
-local function dust_t(orb: BloodStoneOrb struct, n: integer = 10):
-    # draw {_n} dust_color_transition using dustTransition(rgb(160, 48, 48), rgb(250, 250, 50), 1.1) at ({_orb}->location ~ random vector / 5) with offset (random vector) with extra 0.05
-
 local function tick_orb(orb: BloodStoneOrb struct):
     set {_location} to {_orb}->location
     set yaw of {_location} to 0
@@ -76,9 +70,9 @@ local function tick_orb(orb: BloodStoneOrb struct):
     if chance of 1%:
         pulse({_orb})
     else if chance of 5%:
-        dust({_orb})
-    else if chance of 2%:
-        dust_t({_orb})
+        draw vfx_blood_stone_dust(2) at {_orb}->location
+    else if chance of 1%:
+        draw vfx_blood_stone_dust(10) at {_orb}->location
     block at {_location} ~ y(1) is air
     make players see {_location} ~ y(1) as light[level=5]
     wait 10 ticks
@@ -87,7 +81,7 @@ local function tick_orb(orb: BloodStoneOrb struct):
 local function add_orb(orb: BloodStoneOrb struct):
     add {_orb} to {_orb}->blood_stone->orbs
     pulse({_orb})
-    dust_t({_orb}, 20)
+    draw vfx_blood_stone_dust(20) at {_orb}->location
 
 local function break_orb(orb: BloodStoneOrb struct):
     remove {_orb} from {_orb}->blood_stone->orbs
@@ -104,8 +98,7 @@ local function break_orb(orb: BloodStoneOrb struct):
         rotate {_displays::1}, {_displays::2} around y-axis by 10 * {_easing}
         set interaction scale of {_orb}->interaction to {_orb}->scale
         wait 1 tick
-    dust({_orb}, 50)
-    dust_t({_orb}, 20)
+    draw vfx_blood_stone_dust(30) at {_orb}->location
     kill {_orb}->interaction, {_orb}->display, ({_orb}->display's passengers)
     delete {_orb}
 

--- a/source/item/stats/blood_stone.sk
+++ b/source/item/stats/blood_stone.sk
@@ -1,3 +1,4 @@
+
 struct BloodStone:
     stat: Stat struct
     limit: integer
@@ -5,11 +6,6 @@ struct BloodStone:
     orbs_to_be_broken: BloodStoneOrb structs
     rotation: number = 0
     order: integer = 10
-
-local function add(stat: Stat struct) :: BloodStone struct:
-    return BloodStone struct instance:
-        stat: {_stat}
-        limit: 8
 
 struct BloodStoneOrb:
     display: display
@@ -20,9 +16,12 @@ struct BloodStoneOrb:
     size: number
     dynamic scale: vector = vec(this->size)
 
-using for loops
+local function add(stat: Stat struct) -> BloodStone struct:
+    return BloodStone struct instance:
+        stat: {_stat}
+        limit: 8
 
-local function a_blood_stone_orb(blood_stone: BloodStone struct) :: BloodStoneOrb struct:
+local function a_blood_stone_orb(blood_stone: BloodStone struct) -> BloodStoneOrb struct:
     set {_item} to a_item_display()
     set item of {_item} to red_glazed_terracotta, netherrack, fire_coral_block, or nether_wart_block
     set glowing of {_item} to true
@@ -63,10 +62,10 @@ local function pulse(orb: BloodStoneOrb struct):
         wait 1 tick
 
 local function dust(orb: BloodStoneOrb struct, n: integer = 10):
-    draw {_n} dust using dustOption(rgb(160, 48, 48), 1.4) at ({_orb}->location ~ random vector / 5) with offset (random vector) with extra 0.05
+    # draw {_n} dust using dustOption(rgb(160, 48, 48), 1.4) at ({_orb}->location ~ random vector / 5) with offset (random vector) with extra 0.05
 
 local function dust_t(orb: BloodStoneOrb struct, n: integer = 10):
-    draw {_n} dust_color_transition using dustTransition(rgb(160, 48, 48), rgb(250, 250, 50), 1.1) at ({_orb}->location ~ random vector / 5) with offset (random vector) with extra 0.05
+    # draw {_n} dust_color_transition using dustTransition(rgb(160, 48, 48), rgb(250, 250, 50), 1.1) at ({_orb}->location ~ random vector / 5) with offset (random vector) with extra 0.05
 
 local function tick_orb(orb: BloodStoneOrb struct):
     set {_location} to {_orb}->location
@@ -110,7 +109,7 @@ local function break_orb(orb: BloodStoneOrb struct):
     kill {_orb}->interaction, {_orb}->display, ({_orb}->display's passengers)
     delete {_orb}
 
-local function update(bindable: Bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: Bindable struct, stat: Stat struct) -> textcomponent:
     set {_blood_stone} to {_stat}->extension
     bind_set_silently({_bindable}, clamp({_bindable}->value, 0, {_blood_stone}->limit))
     set {_value} to {_bindable}->value

--- a/source/item/stats/critical_chance.sk
+++ b/source/item/stats/critical_chance.sk
@@ -1,3 +1,4 @@
+
 using script reflection
 
 struct CriticalChance:
@@ -5,7 +6,7 @@ struct CriticalChance:
     order: integer = 5
     pre_hit: function = function "pre_hit"
 
-local function add(stat: Stat struct) :: CriticalChance struct:
+local function add(stat: Stat struct) -> CriticalChance struct:
     return CriticalChance struct instance
 
 local function pre_hit(ctx: CombatContext struct, stat: Stat struct):
@@ -18,6 +19,5 @@ local function load():
         name: "Critical Chance"
         extra: 3
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     return a_filled_stat_field("critical_chance", a_fraction({_stat}->current, {_stat}->extension->limit))
-

--- a/source/item/stats/critical_damage.sk
+++ b/source/item/stats/critical_damage.sk
@@ -1,10 +1,11 @@
+
 using script reflection
 
 struct CriticalDamage:
     order: integer = 6
     hit_modifiers: function = function "hit_modifiers"
 
-local function add(stat: Stat struct) :: CriticalDamage struct:
+local function add(stat: Stat struct) -> CriticalDamage struct:
     return CriticalDamage struct instance
 
 local function hit_modifiers(ctx: CombatContext struct, stat: Stat struct):
@@ -18,6 +19,5 @@ local function load():
         name: "Critical Damage"
         extra: 1
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     return a_filled_stat_field("critical_damage", a_percent({_stat}->current))
-

--- a/source/item/stats/damage.sk
+++ b/source/item/stats/damage.sk
@@ -1,10 +1,11 @@
+
 using script reflection
 
 struct Damage:
     order: integer = 4
     hit_modifiers: function = function "hit_modifiers"
 
-local function add(stat: Stat struct) :: Damage struct:
+local function add(stat: Stat struct) -> Damage struct:
     return Damage struct instance
 
 local function hit_modifiers(ctx: CombatContext struct, stat: Stat struct):
@@ -17,6 +18,5 @@ local function load():
         name: "Damage"
         extra: 0
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     return a_filled_stat_field("damage", a_real({_stat}->current))
-

--- a/source/item/stats/primary_attack.sk
+++ b/source/item/stats/primary_attack.sk
@@ -1,9 +1,10 @@
+
 using script reflection
 
 struct PrimaryAttack:
     order: integer = 1
 
-local function add(stat: Stat struct) :: PrimaryAttack struct:
+local function add(stat: Stat struct) -> PrimaryAttack struct:
     return PrimaryAttack struct instance
 
 local function load():
@@ -13,7 +14,7 @@ local function load():
         name: "Primary Attack"
         extra: 5
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     set {_type} to attack_type({_stat}->current)
     set_swing_animation({_stat}->item, {_type}->animation, {_type}->duration)
     return a_filled_stat_field("primary_attack", a_rank({_type}->id, white))

--- a/source/item/stats/range.sk
+++ b/source/item/stats/range.sk
@@ -1,10 +1,11 @@
+
 using script reflection
 
 struct RangeExtension:
     order: integer = 8
     pre_hit: function = function "pre_hit"
 
-local function add(stat: Stat struct) :: RangeExtension struct:
+local function add(stat: Stat struct) -> RangeExtension struct:
     return RangeExtension struct instance
 
 local function pre_hit(ctx: CombatContext struct, stat: Stat struct):
@@ -17,5 +18,5 @@ local function load():
         name: "Range"
         extra: 3
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     return a_filled_stat_field("range", a_real({_stat}->current))

--- a/source/item/stats/secondary_attack.sk
+++ b/source/item/stats/secondary_attack.sk
@@ -1,9 +1,10 @@
+
 using script reflection
 
 struct SecondaryAttack:
     order: integer = 2
 
-local function add(stat: Stat struct) :: SecondaryAttack struct:
+local function add(stat: Stat struct) -> SecondaryAttack struct:
     return SecondaryAttack struct instance
 
 local function load():
@@ -13,7 +14,7 @@ local function load():
         name: "Secondary Attack"
         extra: 5
 
-local function update(bindable: bindable struct, stat: Stat struct) :: textcomponent:
+local function update(bindable: bindable struct, stat: Stat struct) -> textcomponent:
     set {_type} to attack_type({_stat}->current)
     set_consume_animation({_stat}->item, {_type}->animation, {_type}->duration)
     return a_filled_stat_field("secondary_attack", a_rank({_type}->id, white))

--- a/source/logger.sk
+++ b/source/logger.sk
@@ -1,3 +1,4 @@
+
 function load_logger():
     save_component("log_type:info", wrap_around(colored_component("⚡", light blue), c("["), c("]"), 0.8))
     save_component("log_type:debug", wrap_around(colored_component("⁉", orange), c("["), c("]"), 0.8))

--- a/source/main.sk
+++ b/source/main.sk
@@ -1,4 +1,3 @@
-using for loops
 
 on skript load:
     load_all()

--- a/source/player/build.sk
+++ b/source/player/build.sk
@@ -1,3 +1,4 @@
+
 using script reflection
 
 function load_build_state():

--- a/source/player/combat/blood.sk
+++ b/source/player/combat/blood.sk
@@ -1,4 +1,3 @@
-using for loops
 
 function load_blood():
     set {-blood_blocks::*} to red glazed terracotta, red concrete powder, red wool, fire coral block
@@ -16,7 +15,7 @@ function load_blood():
     set fractal type of {-blood_block_generator} to DomainWarpProgressive
     set cellular distance of {-blood_block_generator} to EuclideanSq
 
-local function random_blood_block(at: location) :: itemtype:
+local function random_blood_block(at: location) -> itemtype:
     set {_noise} to noise_at({-blood_block_generator}, {_at}) + 1.2
     set {_size} to {-blood_blocks::size}
     set {_scaled} to ({_size} * {_noise})
@@ -28,7 +27,7 @@ function fx_blood(ctx: CombatContext struct):
     a_generator_at({-blood_sound_generator}, {_ctx}->hit)
 
 function fx_blood_particle(hit: location, damage: number):
-    draw 10 block using red glazed terracotta at {_hit} with offset vec(0.6) with extra {_damage}
+    # draw 10 block using red glazed terracotta at {_hit} with offset vec(0.6) with extra {_damage}
 
 function fx_blood_blocks(entity: entity):
     

--- a/source/player/combat/blood.sk
+++ b/source/player/combat/blood.sk
@@ -27,7 +27,7 @@ function fx_blood(ctx: CombatContext struct):
     a_generator_at({-blood_sound_generator}, {_ctx}->hit)
 
 function fx_blood_particle(hit: location, damage: number):
-    # draw 10 block using red glazed terracotta at {_hit} with offset vec(0.6) with extra {_damage}
+    draw vfx_blood() at {_hit}
 
 function fx_blood_blocks(entity: entity):
     

--- a/source/player/combat/context.sk
+++ b/source/player/combat/context.sk
@@ -1,3 +1,4 @@
+
 struct CombatContext:
     const attacker: player
     const weapon: Item struct
@@ -18,7 +19,7 @@ struct CombatContext:
     critical: boolean = false
     miss: boolean = false
 
-function a_attack_context(attacker: player, weapon: Item struct, tags: strings = {_}) :: CombatContext struct:
+function a_attack_context(attacker: player, weapon: Item struct, tags: strings = {_}) -> CombatContext struct:
 
     return CombatContext struct instance:
         attacker: {_attacker}

--- a/source/player/combat/critical.sk
+++ b/source/player/combat/critical.sk
@@ -1,3 +1,4 @@
+
 function load_criticals():
     set {-generators::critical} to SoundGenerator struct instance:
         id: "entity.player.attack.crit"
@@ -6,4 +7,4 @@ function load_criticals():
 
 function fx_critical(at: location):
     a_generator_at({-generators::critical}, {_at})
-    a_particle({_at}, 50 of electric spark particle)
+    draw 50 electric spark particle at {_at}

--- a/source/player/combat/hit_frames.sk
+++ b/source/player/combat/hit_frames.sk
@@ -1,4 +1,5 @@
-function handle_hit_frames(ctx: CombatContext struct) :: boolean:
+
+function handle_hit_frames(ctx: CombatContext struct) -> boolean:
     return true if is_on_cooldown("hit_frames", {_ctx}->victim) = true
     set_cooldown("hit_frames", {_ctx}->hit_frames, {_ctx}->victim)
     return false

--- a/source/player/combat/hotkey.sk
+++ b/source/player/combat/hotkey.sk
@@ -1,3 +1,4 @@
+
 on drop:
     cancel event
     if state(player) = {-states::play}:

--- a/source/player/combat/impact_frames.sk
+++ b/source/player/combat/impact_frames.sk
@@ -1,3 +1,4 @@
+
 function load_impact_frames():
     set {-generator::impact} to SoundGenerator struct instance:
         id: "entity.player.attack.strong", "block.note_block.bell", "block.note_block.bass"

--- a/source/player/combat/indicator.sk
+++ b/source/player/combat/indicator.sk
@@ -1,3 +1,4 @@
+
 function a_damage_indicator(ctx: CombatContext struct):
     set {_position} to flatten(head of {_ctx}->victim) ~ random vector
     set {_indicator} to a_text_display()

--- a/source/player/combat/main.sk
+++ b/source/player/combat/main.sk
@@ -1,3 +1,4 @@
+
 function load_combat():
     load_ray_handler()
     load_blood()

--- a/source/player/combat/miss.sk
+++ b/source/player/combat/miss.sk
@@ -1,3 +1,4 @@
+
 function load_miss():
     set {-miss_sound_generator::1} to SoundGenerator struct instance:
         id: "entity.breeze.wind_burst", "minecraft:entity.breeze.deflect"

--- a/source/player/combat/pipeline/damage.sk
+++ b/source/player/combat/pipeline/damage.sk
@@ -1,3 +1,4 @@
+
 function on_damage(ctx: CombatContext struct):
     if {_ctx}->critical = true:
         fx_critical({_ctx}->hit)

--- a/source/player/combat/pipeline/death.sk
+++ b/source/player/combat/pipeline/death.sk
@@ -1,3 +1,4 @@
+
 function on_death(victim: entity):
     delete entity within {_victim}
     #trigger_event(machine({_player}), "spectate")

--- a/source/player/combat/pipeline/hit.sk
+++ b/source/player/combat/pipeline/hit.sk
@@ -1,3 +1,4 @@
+
 function on_hit(ctx: CombatContext struct):
     set {_weapon} to {_ctx}->weapon
     set {_item} to (slot {_weapon}->slot of {_weapon}->owner)
@@ -22,24 +23,9 @@ function on_hit(ctx: CombatContext struct):
         handle_hotkey_event({_ctx}->attacker, "on_primary")
     handle_hotkey_event({_ctx}->attacker, "on_hit")
 
-    fx_hit({_ctx})
+    draw (vfx_hit(0.2), vfx_effect_spell(5, red)) at {_ctx}->hit
 
     on_knockback({_ctx})
     on_damage({_ctx})
 
     fx_impact_frames({_ctx})
-
-function fx_hit(ctx: CombatContext struct):
-    set {_hit} to {_ctx}->hit
-    create custom crit:
-        count: 5
-        velocity: outwards
-        extra: 0.2
-    a_particle({_hit}, last created particle)
-    create custom electric_spark:
-        count: 3
-        velocity: outwards
-        extra: 0.2
-    a_particle({_hit}, last created particle)
-    a_particle({_hit}, vfx_effect_spell(5, red))
-    draw 5 effect using particleSpell(red, 1) at {_hit} with delta vec(1, 0, 1) with extra 1

--- a/source/player/combat/pipeline/knockback.sk
+++ b/source/player/combat/pipeline/knockback.sk
@@ -1,3 +1,4 @@
+
 function on_knockback(ctx: CombatContext struct):
     set {_velocity} to (normalized vector from {_ctx}->attacker to {_ctx}->victim) * 0.6
     set velocity of {_ctx}->victim to (velocity of {_ctx}->victim * 0.05)

--- a/source/player/combat/pipeline/stat_processor.sk
+++ b/source/player/combat/pipeline/stat_processor.sk
@@ -1,4 +1,4 @@
-using for loops
+
 using script reflection
 
 function process_stats(ctx: CombatContext struct, phase: string):

--- a/source/player/combat/ray.sk
+++ b/source/player/combat/ray.sk
@@ -1,3 +1,4 @@
+
 function load_ray_handler():
     set {-ray_ignore_entities::*} to display (entitytype), interaction (entitytype)
     set {-ray_ignore_blocks::*} to (all blocks)

--- a/source/player/combat/types/charge.sk
+++ b/source/player/combat/types/charge.sk
@@ -1,4 +1,5 @@
-local function attack_handler(ctx: CombatContext struct) :: boolean:
+
+local function attack_handler(ctx: CombatContext struct) -> boolean:
     return false if {_ctx}->attacker's fall distance > 1
     add 1 to {_ctx}->attack_width
     add 3 to {_ctx}->range

--- a/source/player/combat/types/pull.sk
+++ b/source/player/combat/types/pull.sk
@@ -1,4 +1,5 @@
-local function attack_handler(ctx: CombatContext struct) :: boolean:
+
+local function attack_handler(ctx: CombatContext struct) -> boolean:
     shoot_ray({_ctx})
     return false if {_ctx}->victim is not set
     set {_ctx}->victim's velocity to vector in {_ctx}->attacker's direction * -1

--- a/source/player/combat/types/ray.sk
+++ b/source/player/combat/types/ray.sk
@@ -1,3 +1,4 @@
-local function attack_handler(ctx: CombatContext struct) :: boolean:
+
+local function attack_handler(ctx: CombatContext struct) -> boolean:
     shoot_ray({_ctx})
     return whether {_ctx}->victim is set

--- a/source/player/combat/types/shot.sk
+++ b/source/player/combat/types/shot.sk
@@ -1,4 +1,3 @@
-using for loops
 
 function load_shot_attack_type():
     set {-generator::shot_1} to SoundGenerator struct instance:
@@ -17,23 +16,23 @@ function load_shot_attack_type():
     set {-bullet_splash::*} to colored_component("※", yellow), colored_component("░", white), colored_component("⓪", orange)
 
 
-local function attack_handler(ctx: CombatContext struct) :: boolean:
+local function attack_handler(ctx: CombatContext struct) -> boolean:
     shoot_ray({_ctx})
     set {_head} to {_ctx}->attacker's head
     set {_right} to vector in {_ctx}->attacker's direction
     rotate {_right} around y-axis by -45
     set {_gun} to {_head} ~ {_right} * 0.4 + y(-0.2)
     draw shape (line from {_gun} to {_ctx}->hit):
-        set event-shape's particle to dust_color_transition particle using dustTransition(black, gray, 1)
+        # set event-shape's particle to dust_color_transition particle using dustTransition(black, gray, 1)
     a_generator_at({-generator::shot_1}, {_gun})
     a_generator_at({-generator::shot_2}, {_gun})
     bullet_splash({_gun})
     return whether {_ctx}->victim is set
 
 function bullet_splash(at: location):
-    draw 10 dust_color_transition particle using dustTransition(black, gray, 1) at {_at}
-    draw 5 dust_color_transition particle using dustTransition(yellow, black, 0.6) with offset vec(0.2) at {_at}
-    draw 50 dust_color_transition particle using dustTransition(orange, red, 0.5) with extra 1 at {_at}
+    # draw 10 dust_color_transition particle using dustTransition(black, gray, 1) at {_at}
+    # draw 5 dust_color_transition particle using dustTransition(yellow, black, 0.6) with offset vec(0.2) at {_at}
+    # draw 50 dust_color_transition particle using dustTransition(orange, red, 0.5) with extra 1 at {_at}
     for {_i}, {_component} in {-bullet_splash::*}:
         set {_splash} to a_text_display()
         set teleport duration of {_splash} to 0 ticks

--- a/source/player/combat/types/shot.sk
+++ b/source/player/combat/types/shot.sk
@@ -14,7 +14,7 @@ function load_shot_attack_type():
         random_pitch: range(0.5)
     
     set {-bullet_splash::*} to colored_component("※", yellow), colored_component("░", white), colored_component("⓪", orange)
-
+    set {-bullet_line_particle} to (black dust particle that transitions to gray)
 
 local function attack_handler(ctx: CombatContext struct) -> boolean:
     shoot_ray({_ctx})
@@ -22,17 +22,19 @@ local function attack_handler(ctx: CombatContext struct) -> boolean:
     set {_right} to vector in {_ctx}->attacker's direction
     rotate {_right} around y-axis by -45
     set {_gun} to {_head} ~ {_right} * 0.4 + y(-0.2)
-    draw shape (line from {_gun} to {_ctx}->hit):
-        # set event-shape's particle to dust_color_transition particle using dustTransition(black, gray, 1)
+
+    set {_line} to (line from {_gun} to {_ctx}->hit)
+    set particle of {_line} to {-bullet_line_particle}
+    draw shape {_line}
+
     a_generator_at({-generator::shot_1}, {_gun})
     a_generator_at({-generator::shot_2}, {_gun})
     bullet_splash({_gun})
     return whether {_ctx}->victim is set
 
 function bullet_splash(at: location):
-    # draw 10 dust_color_transition particle using dustTransition(black, gray, 1) at {_at}
-    # draw 5 dust_color_transition particle using dustTransition(yellow, black, 0.6) with offset vec(0.2) at {_at}
-    # draw 50 dust_color_transition particle using dustTransition(orange, red, 0.5) with extra 1 at {_at}
+    draw vfx_bullet_splash() at {_at}
+
     for {_i}, {_component} in {-bullet_splash::*}:
         set {_splash} to a_text_display()
         set teleport duration of {_splash} to 0 ticks

--- a/source/player/dev.sk
+++ b/source/player/dev.sk
@@ -1,3 +1,4 @@
+
 using script reflection
 
 function load_dev_state():

--- a/source/player/machine.sk
+++ b/source/player/machine.sk
@@ -1,12 +1,13 @@
-function a_player_machine(player_wrapper: PlayerWrapper struct, state: string) :: StateMachine struct:
+
+function a_player_machine(player_wrapper: PlayerWrapper struct, state: string) -> StateMachine struct:
     set {_dev::*} to a_transition("dev", {-states::build}, {-states::dev}), a_transition("dev", {-states::play}, {-states::dev})
     set {_play::*} to a_transition("play", {-states::build}, {-states::play}), a_transition("play", {-states::dev}, {-states::play}), a_transition("respawn", {-states::spectate}, {-states::play})
     set {_build::*} to a_transition("build", {-states::play}, {-states::build}), a_transition("build", {-states::dev}, {-states::build})
     set {_spectator} to a_transition("spectate", {-states::play}, {-states::spectate})
     return a_machine(({_dev::*}, {_play::*}, {_build::*}, {_spectator}), {-states::%{_state}%}, {_player_wrapper}, true)
 
-function state(player: player) :: State struct:
+function state(player: player) -> State struct:
     return wrapper({_player})->machine->state
 
-function machine(player: player) :: StateMachine struct:
+function machine(player: player) -> StateMachine struct:
     return wrapper({_player})->machine

--- a/source/player/main.sk
+++ b/source/player/main.sk
@@ -1,3 +1,4 @@
+
 struct PlayerWrapper:
     player: player
     machine: StateMachine struct
@@ -5,7 +6,7 @@ struct PlayerWrapper:
 
     health_bar: HealthBar struct
 
-function wrapper(player: player) :: PlayerWrapper struct:
+function wrapper(player: player) -> PlayerWrapper struct:
     return {-player_wrapper::%{_player}%}
 
 function attach_wrapper(player: player):
@@ -36,4 +37,3 @@ on item held change:
         add ({_dir} * ease_in_out_cubic(loop-counter / 10)) / 10 to camera distance attribute of player
         set camera distance attribute of player to clamp(camera distance attribute of player, 1, 10)
         wait 1 tick
-    

--- a/source/player/play.sk
+++ b/source/player/play.sk
@@ -1,3 +1,4 @@
+
 using script reflection
 
 function load_play_state():

--- a/source/player/spectate.sk
+++ b/source/player/spectate.sk
@@ -1,7 +1,9 @@
+
 using script reflection
 
 function load_spectate_state():
     set {-states::spectate} to a_state("spectate", function "start", function "tick", function "end")
+    set {-spectate::birds_eye} to location(0, 20, 0, world "world", 90, 0)
 
 local function start(event: string, machine: StateMachine struct):
     set {_wrapper} to {_machine}->context
@@ -14,6 +16,7 @@ local function tick(machine: StateMachine struct):
     set {_wrapper} to {_machine}->context
     set {_player} to {_wrapper}->player
     send actionbar component colored_component("SPECTATE MODE", rgb(120, 180, 255)) to {_player}
-    transition_to({_player}, location(0, 20, 0, 0, 90))
+
+    transition_to({_player}, {-spectate::birds_eye})
 
 local function end(event: string, machine: StateMachine struct):

--- a/source/player/target.sk
+++ b/source/player/target.sk
@@ -1,3 +1,4 @@
+
 function process_target(player: player):
     set {_target} to target of {_player} ignoring blocks
     set {_last_target} to metadata "target" of {_player}

--- a/source/player/ui/healthbar.sk
+++ b/source/player/ui/healthbar.sk
@@ -1,5 +1,5 @@
+
 using reflection
-using for loops
 
 struct HealthBar:
     player: player
@@ -11,7 +11,7 @@ function load_health_bar():
     save_component("health_full", colored_component("♮", rgb(236, 71, 93)))
     save_component("health_empty", colored_component("♮", rgb(47, 47, 68)))
 
-function a_health_bar() :: HealthBar struct:
+function a_health_bar() -> HealthBar struct:
     set {_health_bar} to HealthBar struct instance
 
     set {_display} to a_text_display()
@@ -42,7 +42,7 @@ function detach_health_bar(wrapper: PlayerWrapper struct):
     kill {_wrapper}->health_bar->display
     delete {_wrapper}->health_bar
 
-function render_health_bar(health_bar: HealthBar struct, progress: number) :: textcomponent:
+function render_health_bar(health_bar: HealthBar struct, progress: number) -> textcomponent:
 
     set {_value_bindable} to {_health_bar}->bar->value
     set {_value} to lerp_bindable({_value_bindable}, {_progress})

--- a/source/repl.sk
+++ b/source/repl.sk
@@ -1,3 +1,4 @@
+
 command /repl <code: string>:
     permission: op
     trigger:

--- a/source/vfx.sk
+++ b/source/vfx.sk
@@ -10,3 +10,26 @@ function vfx_hit(distribution: number) -> particles:
     set {_particles::1} to 3 crit particle 
     set {_particles::2} to 5 electric spark particle
     return {_particles::*} with offset vec({_distribution}) with extra value 0.2
+
+function vfx_bullet_splash() -> particles:
+    set {_particles::1} to 5 yellow dust particle of size 0.6 that transitions to black with offset vec(0.2)
+    set {_particles::2} to 50 orange dust particle of size 0.5 that transitions to red with extra value 1
+    set {_particles::3} to 10 black dust particle that transitions to gray
+    return {_particles::*}
+
+function vfx_thunder_bolt() -> particles:
+    set {_particles::1} to 3 white dust particle that transitions to rgb(100,150,240)
+    set {_particles::2} to ice item particle
+    return {_particles::*}
+
+function vfx_blood() -> particle:
+    return 10 (red glazed terracotta) block particle with offset vec(0.6) with extra value {_damage}
+
+function vfx_blood_stone_dust(amount: integer = 10) -> particles:
+    set {_particles::1} to rgb(160, 48, 48) dust particle of size 1.4
+    set {_particles::2} to rgb(160, 48, 48) dust particle of size 1.1 that transitions to rgb(250, 250, 50)
+    set particle count of {_particles::*} to {_amount}
+    return {_particles::*} with offset (random vector) with extra value (0.05)
+
+function vfx_block_break(type: itemtype) -> particle:
+    return (10 {_type} block particle with offset y(1) with extra value 1)

--- a/source/vfx.sk
+++ b/source/vfx.sk
@@ -1,4 +1,12 @@
-function vfx_effect_spell(amount: integer, color: color) :: customparticles:
-    #set {_particles::1} to {_amount} of effect particle using particleSpell({_color}, 1) with offset vec(0.3 + ({_amount} / 20)) with extra 0.2
-    set {_particles::2} to {_amount} of dust particle using dustOption({_color}, 1) with offset vec(0.3 + ({_amount} / 20)) with extra 0.2
-    return {_particles::*}
+
+function vfx_effect_spell(amount: integer, color: color) -> particles:
+    set {_offset} to vec(0.3 + ({_amount} / 20))
+    set {_particles::1} to {_color} effect particle of power 1
+    set {_particles::2} to {_color} dust particle
+    set particle count of {_particles::*} to {_amount}
+    return ({_particles::*} with offset {_offset} with extra value 0.2)
+
+function vfx_hit(distribution: number) -> particles:
+    set {_particles::1} to 3 crit particle 
+    set {_particles::2} to 5 electric spark particle
+    return {_particles::*} with offset vec({_distribution}) with extra value 0.2


### PR DESCRIPTION
2.14 is out for Skript, SkBee and skript-particle, so we can convert immediately.

- Switch from `::` return syntax to new, nicer one `->`
- Switch to Skript's new particle system
- Remove expired experiments (for loops)

Closes #4 