### PR TITLE
Remake Effect Lore Component to accept objects

### DIFF
--- a/source/components/text.sk
+++ b/source/components/text.sk
@@ -55,10 +55,12 @@ function a_effect_title(title: string, color: color) -> textcomponent:
     set {_bar} to a_notch_bar(component_from_id("bar"), component_from_id("bar"), {_width}, {_width})
     return merge components {_bar}, px(4), a_angular_brackets(colored_component({_title}, {_color})), px(4), {_bar}
 
-function a_effect_description(line: textcomponent) -> textcomponent:
-    set {_component} to merge components px(6), {_line}
-    set color format of {_component} to {@white}
-    return {_component}
+function a_effect_description(line: objects) -> textcomponent:
+    for {_object} in {_line::*}:
+        set {_component::%loop-counter%} to (minimessage from {_object}) if ({_line} is a text) else ({_object})
+    set {_description} to merge components px(6), {_component::*}
+    set color format of {_description} to {@white}
+    return {_description}
 
 function a_lore(lore: string) -> textcomponent:
     set {_lore} to colored_component("“ %{_lore}% „ ", change_brightness({@gray}, 1.4))

--- a/source/item/special_effects/entangle.sk
+++ b/source/item/special_effects/entangle.sk
@@ -15,8 +15,8 @@ local function update(entangle: Entangle struct) -> textcomponents:
     set {_title} to a_effect_title({_entangle}->name, {_entangle}->color)
     set {_key} to a_event({_entangle}->event)
 
-    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Shoot"))
-    set {_text::2} to a_effect_description(merge components (minimessage from "root projectiles into enemies"))
+    set {_text::1} to a_effect_description(({_key}, " Shoot"))
+    set {_text::2} to a_effect_description(("root projectiles into enemies"))
 
     return {_title}, {_text::*}, blank()
 

--- a/source/item/special_effects/regrowth.sk
+++ b/source/item/special_effects/regrowth.sk
@@ -19,8 +19,8 @@ local function update(regrowth: Regrowth struct) -> textcomponents:
     set {_heal} to a_lore_unit({_regrowth}->heal, "hp/s")
     set {_time} to a_lore_unit(seconds of {_regrowth}->duration, "s")
 
-    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Restores ", {_heal}))
-    set {_text::2} to a_effect_description(merge components (minimessage from "for ", {_time}))
+    set {_text::1} to a_effect_description(({_key}, " Restores ", {_heal}))
+    set {_text::2} to a_effect_description(("for ", {_time}))
 
     return {_title}, {_text::*}, blank()
 

--- a/source/item/special_effects/spin.sk
+++ b/source/item/special_effects/spin.sk
@@ -17,9 +17,9 @@ local function update(spin: Spin struct) -> textcomponents:
     set {_key} to a_key({_spin}->key)
     set {_time} to a_lore_unit(seconds of {_spin}->cooldown, "s")
     set {_radius} to a_lore_unit({_spin}->radius, "m")
-    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Spins you around and hits"))
-    set {_text::2} to a_effect_description(merge components (minimessage from "enemies in a radius ", {_radius}))
-    set {_text::3} to a_effect_description(merge components (minimessage from "shortly ", {_time}))
+    set {_text::1} to a_effect_description(({_key}, " Spins you around and hits"))
+    set {_text::2} to a_effect_description(("enemies in a radius ", {_radius}))
+    set {_text::3} to a_effect_description(("shortly ", {_time}))
     return {_title}, {_text::*}, blank()
 
 local function on_drop(player: player, spin: Spin struct, weapon: Item struct):

--- a/source/item/special_effects/thunderbolt.sk
+++ b/source/item/special_effects/thunderbolt.sk
@@ -20,9 +20,9 @@ local function update(thunderbolt: Thunderbolt struct) -> textcomponents:
     set {_key} to a_key({_thunderbolt}->key)
     set {_amount} to a_lore_unit({_thunderbolt}->amount, "x")
     set {_radius} to a_lore_unit({_thunderbolt}->radius, "m")
-    set {_text::1} to a_effect_description(merge components ({_key}, minimessage from " Casts thunderbolts ", {_amount}))
-    set {_text::2} to a_effect_description(merge components (minimessage from "that drop down and create a"))
-    set {_text::3} to a_effect_description(merge components (minimessage from "splash ", {_radius}))
+    set {_text::1} to a_effect_description(({_key}, " Casts thunderbolts ", {_amount}))
+    set {_text::2} to a_effect_description(("that drop down and create a"))
+    set {_text::3} to a_effect_description(("splash ", {_radius}))
     return {_title}, {_text::*}, blank()
 
 local function on_drop(player: player, thunderbolt: Thunderbolt struct, weapon: Item struct):


### PR DESCRIPTION
This change makes it a lot easier to create a effect without having to mess with mini message and component mixing

- All text gets parsed as a mini message -> component
- All components get accepted as regular components

Allows us to do this: `a_effect_description(({_key}, " Restores ", {_heal}))`.